### PR TITLE
Win condition and game state

### DIFF
--- a/Birthday-2024-Project/MainScenes/main_level.tscn
+++ b/Birthday-2024-Project/MainScenes/main_level.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=7 format=3 uid="uid://bkys348mactw2"]
+[gd_scene load_steps=10 format=3 uid="uid://bkys348mactw2"]
 
 [ext_resource type="Script" path="res://Scripts/GridLogic.gd" id="1_ywtrj"]
 [ext_resource type="Resource" uid="uid://dtycllv72hokg" path="res://Resources/TestLevel.tres" id="4_0al21"]
 [ext_resource type="Script" path="res://Scripts/GameManager.gd" id="4_1cxrf"]
 [ext_resource type="Texture2D" uid="uid://dv6gt6gc6l57t" path="res://Art/GenericPieceArt/Asset 26_opaque.png" id="4_fhdur"]
+[ext_resource type="Script" path="res://Scripts/Game/States/GameEmptyState.gd" id="5_wmt6j"]
+[ext_resource type="Script" path="res://Scripts/Game/States/GamePlayState.gd" id="6_jk8at"]
+[ext_resource type="Script" path="res://Scripts/Game/States/GameWinState.gd" id="7_bviq6"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_5322b"]
 texture = ExtResource("4_fhdur")
@@ -34,14 +37,28 @@ layer_0/tile_data = PackedInt32Array(-131075, 0, 0, -65539, 0, 0, -65538, 0, 0, 
 script = ExtResource("1_ywtrj")
 startingPositions = Array[Vector2i]([Vector2i(6, 0), Vector2i(-6, 0), Vector2i(6, 4), Vector2i(-6, 4), Vector2i(6, -4), Vector2i(-6, -4), Vector2i(0, 6), Vector2i(0, -6)])
 
-[node name="GameManager" type="Node2D" parent="." node_paths=PackedStringArray("grid")]
+[node name="GameManager" type="Node2D" parent="." node_paths=PackedStringArray("grid", "empty_state", "play_state", "win_state")]
 script = ExtResource("4_1cxrf")
 grid = NodePath("../GridMap")
 held_piece_flat_speed = 1.0
 held_piece_distance_speed = 15.0
 held_piece_settle_delay = 0.35
 held_piece_settle_animation_duration = 0.25
+empty_state = NodePath("States/GameEmptyState")
+play_state = NodePath("States/GamePlayState")
+win_state = NodePath("States/GameWinState")
 debug_setupData = ExtResource("4_0al21")
+
+[node name="States" type="Node2D" parent="GameManager"]
+
+[node name="GameEmptyState" type="Node2D" parent="GameManager/States"]
+script = ExtResource("5_wmt6j")
+
+[node name="GamePlayState" type="Node2D" parent="GameManager/States"]
+script = ExtResource("6_jk8at")
+
+[node name="GameWinState" type="Node2D" parent="GameManager/States"]
+script = ExtResource("7_bviq6")
 
 [node name="Camera2D" type="Camera2D" parent="."]
 zoom = Vector2(0.65, 0.65)

--- a/Birthday-2024-Project/MainScenes/main_level.tscn
+++ b/Birthday-2024-Project/MainScenes/main_level.tscn
@@ -64,4 +64,8 @@ script = ExtResource("7_bviq6")
 [node name="Camera2D" type="Camera2D" parent="."]
 zoom = Vector2(0.65, 0.65)
 
-[node name="PuzzleUiManager" parent="." instance=ExtResource("8_40gag")]
+[node name="PuzzleUiManager" parent="." node_paths=PackedStringArray("controller") instance=ExtResource("8_40gag")]
+controller = NodePath("../GameManager")
+
+[connection signal="initialized_event" from="GameManager" to="PuzzleUiManager" method="on_puzzle_initialized"]
+[connection signal="state_changed_event" from="GameManager" to="PuzzleUiManager" method="on_puzzle_state_changed"]

--- a/Birthday-2024-Project/MainScenes/main_level.tscn
+++ b/Birthday-2024-Project/MainScenes/main_level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://bkys348mactw2"]
+[gd_scene load_steps=11 format=3 uid="uid://bkys348mactw2"]
 
 [ext_resource type="Script" path="res://Scripts/GridLogic.gd" id="1_ywtrj"]
 [ext_resource type="Resource" uid="uid://dtycllv72hokg" path="res://Resources/TestLevel.tres" id="4_0al21"]
@@ -7,6 +7,7 @@
 [ext_resource type="Script" path="res://Scripts/Game/States/GameEmptyState.gd" id="5_wmt6j"]
 [ext_resource type="Script" path="res://Scripts/Game/States/GamePlayState.gd" id="6_jk8at"]
 [ext_resource type="Script" path="res://Scripts/Game/States/GameWinState.gd" id="7_bviq6"]
+[ext_resource type="PackedScene" uid="uid://cosap7ka4jc6c" path="res://ScenePrefabs/PuzzleUiManager.tscn" id="8_40gag"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_5322b"]
 texture = ExtResource("4_fhdur")
@@ -62,3 +63,5 @@ script = ExtResource("7_bviq6")
 
 [node name="Camera2D" type="Camera2D" parent="."]
 zoom = Vector2(0.65, 0.65)
+
+[node name="PuzzleUiManager" parent="." instance=ExtResource("8_40gag")]

--- a/Birthday-2024-Project/ScenePrefabs/PuzzleUiManager.tscn
+++ b/Birthday-2024-Project/ScenePrefabs/PuzzleUiManager.tscn
@@ -5,10 +5,13 @@
 [ext_resource type="Script" path="res://Scripts/UI/Puzzle/States/PuzzleUiPlayState.gd" id="3_aj75g"]
 [ext_resource type="Script" path="res://Scripts/UI/Puzzle/States/PuzzleUiWinState.gd" id="4_4ulfu"]
 
-[node name="PuzzleUiManager" type="CanvasLayer"]
+[node name="PuzzleUiManager" type="CanvasLayer" node_paths=PackedStringArray("main_screen", "play_state", "win_state")]
 script = ExtResource("1_e57yp")
+main_screen = NodePath("MainScreen")
+play_state = NodePath("States/PuzzleUiPlayState")
+win_state = NodePath("States/PuzzleUiWinState")
 
-[node name="MainScreen" type="Control" parent="."]
+[node name="MainScreen" type="Control" parent="." node_paths=PackedStringArray("context_button", "reset_button", "win_text")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -16,6 +19,9 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("2_fxt11")
+context_button = NodePath("MarginContainer/HBoxContainer/Context Button")
+reset_button = NodePath("MarginContainer/HBoxContainer/Reset Button")
+win_text = NodePath("Win Text")
 
 [node name="MarginContainer" type="MarginContainer" parent="MainScreen"]
 layout_mode = 1
@@ -37,12 +43,29 @@ size_flags_horizontal = 4
 size_flags_vertical = 4
 text = "Reset"
 
-[node name="Next Button" type="Button" parent="MainScreen/MarginContainer/HBoxContainer"]
+[node name="Context Button" type="Button" parent="MainScreen/MarginContainer/HBoxContainer"]
 custom_minimum_size = Vector2(100, 100)
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
-text = "Next"
+text = "<context>"
+
+[node name="Win Text" type="Label" parent="MainScreen"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -20.0
+offset_top = 181.0
+offset_right = 20.0
+offset_bottom = 204.0
+grow_horizontal = 2
+grow_vertical = 2
+text = "WIN"
+horizontal_alignment = 1
+vertical_alignment = 1
 
 [node name="States" type="Control" parent="."]
 layout_mode = 3

--- a/Birthday-2024-Project/ScenePrefabs/PuzzleUiManager.tscn
+++ b/Birthday-2024-Project/ScenePrefabs/PuzzleUiManager.tscn
@@ -1,0 +1,63 @@
+[gd_scene load_steps=5 format=3 uid="uid://cosap7ka4jc6c"]
+
+[ext_resource type="Script" path="res://Scripts/UI/Puzzle/PuzzleUiManager.gd" id="1_e57yp"]
+[ext_resource type="Script" path="res://Scripts/UI/Puzzle/PuzzleMainScreen.gd" id="2_fxt11"]
+[ext_resource type="Script" path="res://Scripts/UI/Puzzle/States/PuzzleUiPlayState.gd" id="3_aj75g"]
+[ext_resource type="Script" path="res://Scripts/UI/Puzzle/States/PuzzleUiWinState.gd" id="4_4ulfu"]
+
+[node name="PuzzleUiManager" type="CanvasLayer"]
+script = ExtResource("1_e57yp")
+
+[node name="MainScreen" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("2_fxt11")
+
+[node name="MarginContainer" type="MarginContainer" parent="MainScreen"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MainScreen/MarginContainer"]
+layout_mode = 2
+size_flags_vertical = 8
+alignment = 1
+
+[node name="Reset Button" type="Button" parent="MainScreen/MarginContainer/HBoxContainer"]
+custom_minimum_size = Vector2(100, 100)
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+text = "Reset"
+
+[node name="Next Button" type="Button" parent="MainScreen/MarginContainer/HBoxContainer"]
+custom_minimum_size = Vector2(100, 100)
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+text = "Next"
+
+[node name="States" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="PuzzleUiPlayState" type="Control" parent="States"]
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+script = ExtResource("3_aj75g")
+
+[node name="PuzzleUiWinState" type="Control" parent="States"]
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+script = ExtResource("4_4ulfu")

--- a/Birthday-2024-Project/Scripts/Game/States/GameEmptyState.gd
+++ b/Birthday-2024-Project/Scripts/Game/States/GameEmptyState.gd
@@ -1,0 +1,19 @@
+class_name GameEmptyState
+extends GameState
+
+
+#region GameState
+
+func enter_state():
+	pass # Do nothing
+
+
+func exit_state():
+	pass # Do nothing
+
+
+func update_state():
+	pass # Do nothing
+
+
+#endregion GameState

--- a/Birthday-2024-Project/Scripts/Game/States/GamePlayState.gd
+++ b/Birthday-2024-Project/Scripts/Game/States/GamePlayState.gd
@@ -2,6 +2,15 @@ class_name GamePlayState
 extends GameState
 
 
+func reset_puzzle():
+	get_tree().reload_current_scene()
+
+
+func skip_puzzle():
+	print("skip_puzzle is not fully implemented", self)
+	reset_puzzle() # TODO: DELETE THIS WHEN NO LONGER NEEDED.
+
+
 func _on_grid_updated():
 	if manager.grid.freeSpaces == 0:
 		manager.switch_to_win_state()

--- a/Birthday-2024-Project/Scripts/Game/States/GamePlayState.gd
+++ b/Birthday-2024-Project/Scripts/Game/States/GamePlayState.gd
@@ -21,6 +21,7 @@ func _on_grid_updated():
 func enter_state():
 	print("Entering Game Play State")
 	
+	manager._can_interact = true
 	manager.grid.grid_updated.connect(_on_grid_updated)
 
 

--- a/Birthday-2024-Project/Scripts/Game/States/GamePlayState.gd
+++ b/Birthday-2024-Project/Scripts/Game/States/GamePlayState.gd
@@ -1,0 +1,28 @@
+class_name GamePlayState
+extends GameState
+
+
+func _on_grid_updated():
+	if manager.grid.freeSpaces == 0:
+		manager.switch_to_win_state()
+
+
+#region GameState
+
+func enter_state():
+	print("Entering Game Play State")
+	
+	manager.grid.grid_updated.connect(_on_grid_updated)
+
+
+func exit_state():
+	print("Exiting Game Play State")
+	
+	manager.grid.grid_updated.disconnect(_on_grid_updated)
+
+
+func update_state():
+	pass
+
+
+#endregion GameState

--- a/Birthday-2024-Project/Scripts/Game/States/GameState.gd
+++ b/Birthday-2024-Project/Scripts/Game/States/GameState.gd
@@ -1,0 +1,21 @@
+class_name GameState
+extends Node2D
+
+var manager: GameManager
+
+
+func enter_state():
+	pass
+
+
+func exit_state():
+	pass
+
+
+func set_manager(manager: GameManager):
+	self.manager = manager
+
+
+func update_state():
+	pass
+

--- a/Birthday-2024-Project/Scripts/Game/States/GameWinState.gd
+++ b/Birthday-2024-Project/Scripts/Game/States/GameWinState.gd
@@ -15,6 +15,7 @@ func reset_puzzle():
 
 func enter_state():
 	print("Entering Game Win State")
+	manager._can_interact = false
 
 
 func exit_state():

--- a/Birthday-2024-Project/Scripts/Game/States/GameWinState.gd
+++ b/Birthday-2024-Project/Scripts/Game/States/GameWinState.gd
@@ -2,6 +2,15 @@ class_name GameWinState
 extends GameState
 
 
+func next_puzzle():
+	print("next_puzzle is not fully implemented", self)
+	reset_puzzle() # TODO: DELETE THIS WHEN NO LONGER NEEDED.
+
+
+func reset_puzzle():
+	get_tree().reload_current_scene()
+
+
 #region GameState
 
 func enter_state():

--- a/Birthday-2024-Project/Scripts/Game/States/GameWinState.gd
+++ b/Birthday-2024-Project/Scripts/Game/States/GameWinState.gd
@@ -1,0 +1,19 @@
+class_name GameWinState
+extends GameState
+
+
+#region GameState
+
+func enter_state():
+	print("Entering Game Win State")
+
+
+func exit_state():
+	print("Exiting Game Win State")
+
+
+func update_state():
+	pass # Do nothing
+
+
+#endregion GameState

--- a/Birthday-2024-Project/Scripts/GameManager.gd
+++ b/Birthday-2024-Project/Scripts/GameManager.gd
@@ -22,6 +22,7 @@ var held_piece_settled: bool
 var previous_mouse_position: Vector2
 var remaining_settle_delay: float
 
+var _can_interact: bool # TODO: DELETE THIS WHEN NO LONGER NEEDED.
 var _current_state: GameState
 var _is_inititialized: bool
 var _previous_state: GameState
@@ -55,7 +56,7 @@ func _switch_state(state: GameState):
 
 
 func on_piece_clicked(clicked_piece: PieceLogic):
-	if held_piece != null:
+	if not _can_interact or held_piece != null:
 		return
 	
 	held_piece = clicked_piece
@@ -79,7 +80,7 @@ func _process(delta):
 		initialized_event.emit()
 		switch_to_play_state()
 	
-	if held_piece == null:
+	if not _can_interact or held_piece == null:
 		return
 		
 	_do_held_piece_settle(delta)

--- a/Birthday-2024-Project/Scripts/GameManager.gd
+++ b/Birthday-2024-Project/Scripts/GameManager.gd
@@ -8,6 +8,12 @@ extends Node2D
 @export var held_piece_settle_delay: float # The amount of time the held piece must remain motionless before settling
 @export var held_piece_settle_animation_duration: float # The amount of time the held piece takes to move to it's settled position
 
+@export_group("States")
+@export var empty_state: GameEmptyState
+@export var play_state: GamePlayState
+@export var win_state: GameWinState
+
+@export_group("")
 #TODO: have this passed by the level selector in the future
 @export var debug_setupData : LevelSetup
 
@@ -15,6 +21,32 @@ var held_piece: PieceLogic
 var held_piece_settled: bool
 var previous_mouse_position: Vector2
 var remaining_settle_delay: float
+
+var _current_state: GameState
+var _previous_state: GameState
+
+signal state_changed_event(state)
+
+
+func switch_to_play_state():
+	_switch_state(play_state)
+
+
+func switch_to_win_state():
+	_switch_state(win_state)
+
+
+func _switch_state(state: GameState):
+	_previous_state = _current_state
+	_current_state = state
+	
+	if _previous_state != null:
+		_previous_state.exit_state()
+	
+	_current_state.enter_state()
+	
+	state_changed_event.emit(state)
+
 
 func on_piece_clicked(clicked_piece: PieceLogic):
 	if held_piece != null:
@@ -25,6 +57,13 @@ func on_piece_clicked(clicked_piece: PieceLogic):
 	_reset_settled()
 
 func _ready():
+	# State
+	_current_state = empty_state
+	empty_state.set_manager(self)
+	play_state.set_manager(self)
+	win_state.set_manager(self)
+	switch_to_play_state()
+	
 	#TODO: Load level using Level Select
 	grid.LoadLevel(debug_setupData)
 

--- a/Birthday-2024-Project/Scripts/GameManager.gd
+++ b/Birthday-2024-Project/Scripts/GameManager.gd
@@ -23,9 +23,15 @@ var previous_mouse_position: Vector2
 var remaining_settle_delay: float
 
 var _current_state: GameState
+var _is_inititialized: bool
 var _previous_state: GameState
 
+signal initialized_event()
 signal state_changed_event(state)
+
+
+func get_current_state() -> GameState:
+	return _current_state
 
 
 func switch_to_play_state():
@@ -62,12 +68,17 @@ func _ready():
 	empty_state.set_manager(self)
 	play_state.set_manager(self)
 	win_state.set_manager(self)
-	switch_to_play_state()
 	
 	#TODO: Load level using Level Select
 	grid.LoadLevel(debug_setupData)
 
 func _process(delta):
+	if not _is_inititialized:
+		_is_inititialized = true
+		
+		initialized_event.emit()
+		switch_to_play_state()
+	
 	if held_piece == null:
 		return
 		

--- a/Birthday-2024-Project/Scripts/GridLogic.gd
+++ b/Birthday-2024-Project/Scripts/GridLogic.gd
@@ -23,6 +23,9 @@ var xMaxGrid : int = 0
 var yMinGrid : int = 0
 var yMaxGrid : int = 0
 
+signal grid_updated
+
+
 func ClearLevel():
 	freeSpaces = 0
 	xMinGrid = 0
@@ -90,6 +93,11 @@ func GridCoordinateToPosition(gridCoords : Vector2i) -> Vector2:
 	#account for grid offset due to centering
 	return _GridCoordinateToPosition(gridCoords) + global_position
 
+
+func get_free_spaces() -> int:
+	return freeSpaces
+
+
 func GetGridSpace(gridCoords : Vector2i) -> GridSpaceInfo:
 	return _gridSpaces[gridCoords.x + MAX_WIDTH][gridCoords.y + MAX_HEIGHT]
 	
@@ -155,7 +163,8 @@ func PlacePiece(piece : PieceLogic) -> bool:
 	SetGridSpacesByPieceShape(pieceCoords, GridSpaceInfo.GridSpaceStatus.OCCUPIED, piece)
 	piece.AssignMapGridCoordinates(pieceCoords)
 	
-	#TODO: check win condition HERE
+	grid_updated.emit()
+	
 	return true
 
 func RemovePieceByCoordinates(gridCoord : Vector2i) -> PieceLogic:

--- a/Birthday-2024-Project/Scripts/UI/Puzzle/PuzzleMainScreen.gd
+++ b/Birthday-2024-Project/Scripts/UI/Puzzle/PuzzleMainScreen.gd
@@ -2,5 +2,15 @@ class_name PuzzleMainScreen
 extends Control
 
 
-@export var next_button: Button
+@export_group("UI Elements")
+@export var context_button: Button
 @export var reset_button: Button
+@export var win_text: Label
+
+
+func show_hide_win_text(is_showing: bool):
+	if is_showing:
+		win_text.show()
+	else:
+		win_text.hide()
+

--- a/Birthday-2024-Project/Scripts/UI/Puzzle/PuzzleMainScreen.gd
+++ b/Birthday-2024-Project/Scripts/UI/Puzzle/PuzzleMainScreen.gd
@@ -1,0 +1,6 @@
+class_name PuzzleMainScreen
+extends Control
+
+
+@export var next_button: Button
+@export var reset_button: Button

--- a/Birthday-2024-Project/Scripts/UI/Puzzle/PuzzleUiManager.gd
+++ b/Birthday-2024-Project/Scripts/UI/Puzzle/PuzzleUiManager.gd
@@ -1,0 +1,57 @@
+class_name PuzzleUiManager
+extends CanvasLayer
+
+
+@export_group("UI Elements")
+@export var main_screen: PuzzleMainScreen
+
+@export_group("States")
+@export var play_state: PuzzleUiPlayState
+@export var win_state: PuzzleUiWinState
+
+var _current_state: PuzzleUiState
+
+
+func on_puzzle_initialized():
+	pass
+
+
+func on_puzzle_state_changed(state: GameState):
+	match state:
+		GamePlayState:
+			_switch_state(play_state)
+		
+		GameWinState:
+			_switch_state(win_state)
+		
+		_:
+			printerr("Unhandled puzzle state in puzzle UI Manager", self)
+
+
+func show_main_screen():
+	_disable_all_screens()
+	main_screen.show()
+
+
+func _disable_all_screens():
+	main_screen.hide()
+
+
+func _switch_state(state: PuzzleUiState):
+	var previous_state = _current_state
+	_current_state = state
+	
+	if previous_state != null:
+		previous_state.exit_state()
+	
+	_current_state.enter_state()
+
+
+#region Node
+
+func _process(delta):
+	if _current_state != null:
+		_current_state.update_state()
+
+
+#endregion Node

--- a/Birthday-2024-Project/Scripts/UI/Puzzle/PuzzleUiManager.gd
+++ b/Birthday-2024-Project/Scripts/UI/Puzzle/PuzzleUiManager.gd
@@ -1,8 +1,9 @@
 class_name PuzzleUiManager
 extends CanvasLayer
 
+@export var controller: GameManager
 
-@export_group("UI Elements")
+@export_group("Screens")
 @export var main_screen: PuzzleMainScreen
 
 @export_group("States")
@@ -17,15 +18,22 @@ func on_puzzle_initialized():
 
 
 func on_puzzle_state_changed(state: GameState):
-	match state:
-		GamePlayState:
-			_switch_state(play_state)
-		
-		GameWinState:
-			_switch_state(win_state)
-		
-		_:
-			printerr("Unhandled puzzle state in puzzle UI Manager", self)
+	if state is GamePlayState:
+		_switch_state(play_state)
+	elif state is GameWinState:
+		_switch_state(win_state)
+	else:
+		printerr("Unhandled puzzle state in puzzle UI Manager", self)
+	
+	#match state:
+		#GamePlayState:
+			#_switch_state(play_state)
+		#
+		#GameWinState:
+			#_switch_state(win_state)
+		#
+		#_:
+			#printerr("Unhandled puzzle state in puzzle UI Manager", self)
 
 
 func show_main_screen():
@@ -52,6 +60,13 @@ func _switch_state(state: PuzzleUiState):
 func _process(delta):
 	if _current_state != null:
 		_current_state.update_state()
+
+
+func _ready():
+	play_state._controller = controller
+	play_state._ui_manager = self
+	win_state._controller = controller
+	win_state._ui_manager = self
 
 
 #endregion Node

--- a/Birthday-2024-Project/Scripts/UI/Puzzle/States/PuzzleUiPlayState.gd
+++ b/Birthday-2024-Project/Scripts/UI/Puzzle/States/PuzzleUiPlayState.gd
@@ -2,14 +2,43 @@ class_name PuzzleUiPlayState
 extends PuzzleUiState
 
 
+var _state: GamePlayState
+
+
+func _on_reset_clicked():
+	_state.reset_puzzle()
+
+
+func _on_skip_clicked():
+	_state.skip_puzzle()
+
+
 #region PuzzleUiState
 
 func enter_state():
-	pass
+	var state = _controller.get_current_state()
+	
+	if not state is GamePlayState:
+		printerr("Puzzle is not in play state", self)
+		return
+	
+	_state = state
+	
+	_ui_manager.show_main_screen()
+	
+	var screen = _ui_manager.main_screen
+	screen.show_hide_win_text(false)
+	screen.context_button.text = "Skip"
+	screen.context_button.button_up.connect(_on_skip_clicked)
+	screen.reset_button.button_up.connect(_on_reset_clicked)
 
 
 func exit_state():
-	pass
+	_state = null
+	
+	var screen = _ui_manager.main_screen
+	screen.context_button.button_up.disconnect(_on_skip_clicked)
+	screen.reset_button.button_up.disconnect(_on_reset_clicked)
 
 
 func update_state():

--- a/Birthday-2024-Project/Scripts/UI/Puzzle/States/PuzzleUiPlayState.gd
+++ b/Birthday-2024-Project/Scripts/UI/Puzzle/States/PuzzleUiPlayState.gd
@@ -1,0 +1,19 @@
+class_name PuzzleUiPlayState
+extends PuzzleUiState
+
+
+#region PuzzleUiState
+
+func enter_state():
+	pass
+
+
+func exit_state():
+	pass
+
+
+func update_state():
+	pass
+
+
+#endregion PuzzleUiState

--- a/Birthday-2024-Project/Scripts/UI/Puzzle/States/PuzzleUiState.gd
+++ b/Birthday-2024-Project/Scripts/UI/Puzzle/States/PuzzleUiState.gd
@@ -2,6 +2,7 @@ class_name PuzzleUiState
 extends Control
 
 
+var _controller: GameManager
 var _ui_manager: PuzzleUiManager
 
 

--- a/Birthday-2024-Project/Scripts/UI/Puzzle/States/PuzzleUiState.gd
+++ b/Birthday-2024-Project/Scripts/UI/Puzzle/States/PuzzleUiState.gd
@@ -1,0 +1,18 @@
+class_name PuzzleUiState
+extends Control
+
+
+var _ui_manager: PuzzleUiManager
+
+
+func enter_state():
+	pass
+
+
+func exit_state():
+	pass
+
+
+func update_state():
+	pass
+

--- a/Birthday-2024-Project/Scripts/UI/Puzzle/States/PuzzleUiWinState.gd
+++ b/Birthday-2024-Project/Scripts/UI/Puzzle/States/PuzzleUiWinState.gd
@@ -1,0 +1,19 @@
+class_name PuzzleUiWinState
+extends PuzzleUiState
+
+
+#region PuzzleUiState
+
+func enter_state():
+	pass
+
+
+func exit_state():
+	pass
+
+
+func update_state():
+	pass
+
+
+#endregion PuzzleUiState

--- a/Birthday-2024-Project/Scripts/UI/Puzzle/States/PuzzleUiWinState.gd
+++ b/Birthday-2024-Project/Scripts/UI/Puzzle/States/PuzzleUiWinState.gd
@@ -2,14 +2,43 @@ class_name PuzzleUiWinState
 extends PuzzleUiState
 
 
+var _state: GameWinState
+
+
+func _on_next_clicked():
+	_state.next_puzzle()
+
+
+func _on_reset_clicked():
+	_state.reset_puzzle()
+
+
 #region PuzzleUiState
 
 func enter_state():
-	pass
+	var state = _controller.get_current_state()
+	
+	if not state is GameWinState:
+		printerr("Puzzle is not in win state", self)
+		return
+	
+	_state = state
+	
+	_ui_manager.show_main_screen()
+	
+	var screen = _ui_manager.main_screen
+	screen.show_hide_win_text(true)
+	screen.context_button.text = "Next"
+	screen.context_button.button_up.connect(_on_next_clicked)
+	screen.reset_button.button_up.connect(_on_reset_clicked)
 
 
 func exit_state():
-	pass
+	_state = null
+	
+	var screen = _ui_manager.main_screen
+	screen.context_button.button_up.disconnect(_on_next_clicked)
+	screen.reset_button.button_up.disconnect(_on_reset_clicked)
 
 
 func update_state():


### PR DESCRIPTION
# Description

Added game states to `GameManager` to handle play and win states.

## Related issue(s)

https://github.com/Saplings-Projects/Birthday-2024/issues/4

## List of changes

A more detailed list of the changes.

### Added
- Signal to `GridLogic` to emit event when a tile is placed
- Getter for free spaces to `GridLogic`
- `GameState` class
- `GameEmptyState` class
- `GamePlayState` class
- `GameWinState` class
- Added initial states to `GameManager`
- Added initial UI to main scene for resetting the puzzle and displaying when the game is won

### Changed
- `GameManager` now disables interacting with puzzle pieces after winning

## Tests

None

## Additional notes

I think game states could be a good way of splitting up some game logic and make it easier to manage things. Such as making pieces only interactable during play state.
