### PR TITLE
Added initial main menu

### DIFF
--- a/Birthday-2024-Project/MainScenes/main_menu.tscn
+++ b/Birthday-2024-Project/MainScenes/main_menu.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=3 format=3 uid="uid://8wblerx67ki"]
+
+[ext_resource type="PackedScene" uid="uid://djitpkrdyydxc" path="res://ScenePrefabs/MainMenuController.tscn" id="1_2fpfx"]
+[ext_resource type="PackedScene" uid="uid://gfva2owqvlhw" path="res://ScenePrefabs/MainMenuUiManager.tscn" id="1_yk612"]
+
+[node name="MainMenu" type="Node2D"]
+
+[node name="MainMenuController" parent="." instance=ExtResource("1_2fpfx")]
+
+[node name="MainMenuUiManager" parent="." node_paths=PackedStringArray("conntroller") instance=ExtResource("1_yk612")]
+conntroller = NodePath("../MainMenuController")
+
+[connection signal="initialized_event" from="MainMenuController" to="MainMenuUiManager" method="on_main_menu_initialized"]
+[connection signal="state_changed_event" from="MainMenuController" to="MainMenuUiManager" method="on_main_menu_state_changed"]

--- a/Birthday-2024-Project/ScenePrefabs/MainMenuController.tscn
+++ b/Birthday-2024-Project/ScenePrefabs/MainMenuController.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=4 format=3 uid="uid://djitpkrdyydxc"]
+
+[ext_resource type="Script" path="res://Scripts/Game/MainMenu/MainMenuController.gd" id="1_bhs7v"]
+[ext_resource type="Script" path="res://Scripts/Game/MainMenu/States/MainMenuEmptyState.gd" id="2_2b8j4"]
+[ext_resource type="Script" path="res://Scripts/Game/MainMenu/States/MainMenuStartState.gd" id="3_mmrix"]
+
+[node name="MainMenuController" type="Node2D" node_paths=PackedStringArray("empty_state", "start_state")]
+script = ExtResource("1_bhs7v")
+empty_state = NodePath("States/MainMenuEmptyState")
+start_state = NodePath("States/MainMenuStartState")
+
+[node name="States" type="Node2D" parent="."]
+
+[node name="MainMenuEmptyState" type="Node2D" parent="States"]
+script = ExtResource("2_2b8j4")
+
+[node name="MainMenuStartState" type="Node2D" parent="States"]
+script = ExtResource("3_mmrix")

--- a/Birthday-2024-Project/ScenePrefabs/MainMenuUiManager.tscn
+++ b/Birthday-2024-Project/ScenePrefabs/MainMenuUiManager.tscn
@@ -1,0 +1,100 @@
+[gd_scene load_steps=4 format=3 uid="uid://gfva2owqvlhw"]
+
+[ext_resource type="Script" path="res://Scripts/UI/MainMenu/MainMenuUiManager.gd" id="1_lofx7"]
+[ext_resource type="Script" path="res://Scripts/UI/MainMenu/MainMenuStartScreen.gd" id="2_n7aum"]
+[ext_resource type="Script" path="res://Scripts/UI/MainMenu/States/MainMenuUiStartState.gd" id="3_vnjds"]
+
+[node name="MainMenuUiManager" type="CanvasLayer" node_paths=PackedStringArray("start_screen", "start_state")]
+script = ExtResource("1_lofx7")
+start_screen = NodePath("StartScreen")
+start_state = NodePath("States/MainMenuUiStartState")
+
+[node name="StartScreen" type="Control" parent="." node_paths=PackedStringArray("credits_button", "exit_button", "gallary_button", "play_button", "settings_button")]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("2_n7aum")
+credits_button = NodePath("Panel/Navigation Buttons/Credits Button")
+exit_button = NodePath("Panel/Utility Buttons/Exit Button")
+gallary_button = NodePath("Panel/Navigation Buttons/Gallery Button")
+play_button = NodePath("Panel/Navigation Buttons/Play Button")
+settings_button = NodePath("Panel/Utility Buttons/Settings Button")
+
+[node name="Panel" type="Panel" parent="StartScreen"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Title" type="Label" parent="StartScreen/Panel"]
+layout_mode = 1
+anchors_preset = 14
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_top = -251.0
+offset_bottom = -108.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 4
+text = "FAUNA'S 2024
+BIRTHDAY"
+horizontal_alignment = 1
+
+[node name="Navigation Buttons" type="VBoxContainer" parent="StartScreen/Panel"]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -121.0
+offset_top = -432.0
+offset_right = 121.0
+grow_horizontal = 2
+grow_vertical = 0
+
+[node name="Play Button" type="Button" parent="StartScreen/Panel/Navigation Buttons"]
+layout_mode = 2
+text = "Play"
+
+[node name="Gallery Button" type="Button" parent="StartScreen/Panel/Navigation Buttons"]
+layout_mode = 2
+text = "Gallery"
+
+[node name="Credits Button" type="Button" parent="StartScreen/Panel/Navigation Buttons"]
+layout_mode = 2
+text = "Credits"
+
+[node name="Utility Buttons" type="HBoxContainer" parent="StartScreen/Panel"]
+layout_mode = 1
+anchors_preset = 10
+anchor_right = 1.0
+offset_bottom = 73.0
+grow_horizontal = 2
+alignment = 2
+
+[node name="Settings Button" type="Button" parent="StartScreen/Panel/Utility Buttons"]
+layout_mode = 2
+text = "Settings"
+
+[node name="Exit Button" type="Button" parent="StartScreen/Panel/Utility Buttons"]
+layout_mode = 2
+text = "Exit"
+
+[node name="States" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="MainMenuUiStartState" type="Control" parent="States"]
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+script = ExtResource("3_vnjds")

--- a/Birthday-2024-Project/Scripts/Game/MainMenu/MainMenuController.gd
+++ b/Birthday-2024-Project/Scripts/Game/MainMenu/MainMenuController.gd
@@ -1,0 +1,58 @@
+class_name MainMenuController
+extends Node2D
+
+
+@export_group("States")
+@export var empty_state: MainMenuEmptyState
+@export var start_state: MainMenuStartState
+
+var _current_state: MainMenuState
+var _is_inititialized: bool
+var _previous_state: MainMenuState
+
+signal initialized_event()
+signal state_changed_event(state)
+
+
+func get_current_state() -> MainMenuState:
+	return _current_state
+
+
+func switch_to_start_state():
+	_switch_state(start_state)
+
+
+func _switch_state(state: MainMenuState):
+	_previous_state = _current_state
+	_current_state = state
+	
+	if _previous_state != null:
+		_previous_state.exit_state()
+	
+	_current_state.enter_state()
+	
+	state_changed_event.emit(_current_state)
+
+
+#region Node
+
+func _process(delta):
+	if not _is_inititialized:
+		_is_inititialized = true
+		
+		initialized_event.emit()
+		
+		# Pick the appropriate state based on game data (e.g. exiting a level or starting up)
+		switch_to_start_state()
+	
+	_current_state.update_state()
+
+
+func _ready():
+	# State
+	_current_state = empty_state
+	empty_state.controller = self
+	start_state.controller = self
+
+
+#endregion Node

--- a/Birthday-2024-Project/Scripts/Game/MainMenu/States/MainMenuEmptyState.gd
+++ b/Birthday-2024-Project/Scripts/Game/MainMenu/States/MainMenuEmptyState.gd
@@ -1,0 +1,19 @@
+class_name MainMenuEmptyState
+extends MainMenuState
+
+
+#region MainMenuState
+
+func enter_state():
+	pass # Do nothing
+
+
+func exit_state():
+	pass # Do nothing
+
+
+func update_state():
+	pass # Do nothing
+
+
+#endregion MainMenuState

--- a/Birthday-2024-Project/Scripts/Game/MainMenu/States/MainMenuStartState.gd
+++ b/Birthday-2024-Project/Scripts/Game/MainMenu/States/MainMenuStartState.gd
@@ -2,6 +2,24 @@ class_name MainMenuStartState
 extends MainMenuState
 
 
+func exit_game():
+	get_tree().quit()
+
+
+func go_to_credits():
+	# TODO: Implement function
+	print("go_to_credits is not implemented in MainMenuStartState")
+
+
+func go_to_gallery():
+	# TODO: Implement function
+	print("go_to_gallery is not implemented in MainMenuStartState")
+
+
+func play():
+	get_tree().change_scene_to_file("res://MainScenes/main_level.tscn")
+
+
 #region MainMenuState
 
 func enter_state():

--- a/Birthday-2024-Project/Scripts/Game/MainMenu/States/MainMenuStartState.gd
+++ b/Birthday-2024-Project/Scripts/Game/MainMenu/States/MainMenuStartState.gd
@@ -1,0 +1,19 @@
+class_name MainMenuStartState
+extends MainMenuState
+
+
+#region MainMenuState
+
+func enter_state():
+	pass
+
+
+func exit_state():
+	pass
+
+
+func update_state():
+	pass
+
+
+#endregion MainMenuState

--- a/Birthday-2024-Project/Scripts/Game/MainMenu/States/MainMenuState.gd
+++ b/Birthday-2024-Project/Scripts/Game/MainMenu/States/MainMenuState.gd
@@ -1,0 +1,18 @@
+class_name MainMenuState
+extends Node2D
+
+
+var controller: MainMenuController
+
+
+func enter_state():
+	pass
+
+
+func exit_state():
+	pass
+
+
+func update_state():
+	pass
+

--- a/Birthday-2024-Project/Scripts/UI/MainMenu/MainMenuStartScreen.gd
+++ b/Birthday-2024-Project/Scripts/UI/MainMenu/MainMenuStartScreen.gd
@@ -1,0 +1,10 @@
+class_name MainMenuStartScreen
+extends Control
+
+
+@export_group("UI Elements")
+@export var credits_button: Button
+@export var exit_button: Button
+@export var gallary_button: Button
+@export var play_button: Button
+@export var settings_button: Button

--- a/Birthday-2024-Project/Scripts/UI/MainMenu/MainMenuUiManager.gd
+++ b/Birthday-2024-Project/Scripts/UI/MainMenu/MainMenuUiManager.gd
@@ -1,0 +1,58 @@
+class_name MainMenuUiManager
+extends CanvasLayer
+
+
+@export var conntroller: MainMenuController
+
+@export_group("Screens")
+@export var start_screen: MainMenuStartScreen
+
+@export_group("States")
+@export var start_state: MainMenuUiStartState
+
+var _current_state: MainMenuUiState
+
+
+func on_main_menu_initialized():
+	pass
+
+
+func on_main_menu_state_changed(state: MainMenuState):
+	if state is MainMenuStartState:
+		_switch_state(start_state)
+	else:
+		printerr("Unhandled main menu state in main menu UI Manager")
+
+
+func show_start_screen():
+	_disable_all_screans()
+	start_screen.show()
+
+
+func _disable_all_screans():
+	start_screen.hide()
+
+
+func _switch_state(state: MainMenuUiState):
+	var previous_state = _current_state
+	_current_state = state
+	
+	if previous_state != null:
+		previous_state.exit_state()
+	
+	_current_state.enter_state()
+
+
+#region Node
+
+func _process(delta):
+	if _current_state != null:
+		_current_state.update_state()
+
+
+func _ready():
+	start_state._controller = conntroller
+	start_state._ui_manager = self
+
+
+#endregion None

--- a/Birthday-2024-Project/Scripts/UI/MainMenu/States/MainMenuUiStartState.gd
+++ b/Birthday-2024-Project/Scripts/UI/MainMenu/States/MainMenuUiStartState.gd
@@ -1,0 +1,64 @@
+class_name MainMenuUiStartState
+extends MainMenuUiState
+
+
+var _state: MainMenuStartState
+
+
+func _on_credits_clicked():
+	print("_on_credits_clicked is not implemented in MainMenuUiStartState")
+
+
+func _on_exit_clicked():
+	print("_on_exit_clicked is not implemented in MainMenuUiStartState")
+
+
+func _on_gallery_clicked():
+	print("_on_gallery_clicked is not implemented in MainMenuUiStartState")
+
+
+func _on_play_clicked():
+	print("_on_play_clicked is not implemented in MainMenuUiStartState")
+
+
+func _on_settings_clicked():
+	print("_on_settings_clicked is not implemented in MainMenuUiStartState")
+
+
+#region MainMenuUiState
+
+func enter_state():
+	var state = _controller.get_current_state()
+	
+	if not state is MainMenuStartState:
+		printerr("Main menu is not in start state")
+		return
+	
+	_state = state
+	
+	_ui_manager.show_start_screen()
+	
+	var screen = _ui_manager.start_screen
+	screen.credits_button.button_up.connect(_on_credits_clicked)
+	screen.exit_button.button_up.connect(_on_exit_clicked)
+	screen.gallary_button.button_up.connect(_on_gallery_clicked)
+	screen.play_button.button_up.connect(_on_play_clicked)
+	screen.settings_button.button_up.connect(_on_settings_clicked)
+
+
+func exit_state():
+	_state = null
+	
+	var screen = _ui_manager.start_screen
+	screen.credits_button.button_up.disconnect(_on_credits_clicked)
+	screen.exit_button.button_up.disconnect(_on_exit_clicked)
+	screen.gallary_button.button_up.disconnect(_on_gallery_clicked)
+	screen.play_button.button_up.disconnect(_on_play_clicked)
+	screen.settings_button.button_up.disconnect(_on_settings_clicked)
+
+
+func update_state():
+	pass
+
+
+#endregion MainMenuUiState

--- a/Birthday-2024-Project/Scripts/UI/MainMenu/States/MainMenuUiStartState.gd
+++ b/Birthday-2024-Project/Scripts/UI/MainMenu/States/MainMenuUiStartState.gd
@@ -6,22 +6,23 @@ var _state: MainMenuStartState
 
 
 func _on_credits_clicked():
-	print("_on_credits_clicked is not implemented in MainMenuUiStartState")
+	_state.go_to_credits()
 
 
 func _on_exit_clicked():
-	print("_on_exit_clicked is not implemented in MainMenuUiStartState")
+	_state.exit_game()
 
 
 func _on_gallery_clicked():
-	print("_on_gallery_clicked is not implemented in MainMenuUiStartState")
+	_state.go_to_gallery()
 
 
 func _on_play_clicked():
-	print("_on_play_clicked is not implemented in MainMenuUiStartState")
+	_state.play()
 
 
 func _on_settings_clicked():
+	# TODO: Pull up a settings screen.
 	print("_on_settings_clicked is not implemented in MainMenuUiStartState")
 
 

--- a/Birthday-2024-Project/Scripts/UI/MainMenu/States/MainMenuUiState.gd
+++ b/Birthday-2024-Project/Scripts/UI/MainMenu/States/MainMenuUiState.gd
@@ -1,0 +1,19 @@
+class_name MainMenuUiState
+extends Control
+
+
+var _controller: MainMenuController
+var _ui_manager: MainMenuUiManager
+
+
+func enter_state():
+	pass
+
+
+func exit_state():
+	pass
+
+
+func update_state():
+	pass
+

--- a/Birthday-2024-Project/Scripts/UI/Puzzle/PuzzleUiManager.gd
+++ b/Birthday-2024-Project/Scripts/UI/Puzzle/PuzzleUiManager.gd
@@ -24,16 +24,6 @@ func on_puzzle_state_changed(state: GameState):
 		_switch_state(win_state)
 	else:
 		printerr("Unhandled puzzle state in puzzle UI Manager", self)
-	
-	#match state:
-		#GamePlayState:
-			#_switch_state(play_state)
-		#
-		#GameWinState:
-			#_switch_state(win_state)
-		#
-		#_:
-			#printerr("Unhandled puzzle state in puzzle UI Manager", self)
 
 
 func show_main_screen():

--- a/Birthday-2024-Project/project.godot
+++ b/Birthday-2024-Project/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Birthday-2024"
-run/main_scene="res://MainScenes/main_level.tscn"
+run/main_scene="res://MainScenes/main_menu.tscn"
 config/features=PackedStringArray("4.2", "GL Compatibility")
 config/icon="res://icon.svg"
 


### PR DESCRIPTION
# Description

Added initial classes and scenes to support a main menu for players to navigate to different scenes.

## Related issue(s)

https://github.com/Saplings-Projects/Birthday-2024/issues/9

## List of changes

### Added
- Added initial class `MainMenuController`
- Added initial class `MainMenuState`
- Added initial class `MainMenuEmptyState`
- Added initial class `MainMenuStartState`
- Added initial class `MainMenuStartState`
- Added initial class `MainMenuUiManager`
- Added initial class `MainMenuStartScreen`
- Added initial class `MainMenuUiState`
- Added initial class `MainMenuUiStartState`
- Added scene prefab for a main menu controller
- Added scene prefab for a main menu UI manager
- Added initial main menu scene

### Changed
- The main menu scene is now the default scene for the project

## Tests

None

## Additional notes

None
