### PR TITLE
Add game master and controllers for managing user settings

### DIFF
--- a/Birthday-2024-Project/Resources/Video/1366x768.tres
+++ b/Birthday-2024-Project/Resources/Video/1366x768.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="ScreenResolution" load_steps=2 format=3 uid="uid://dth7hfnnen2p8"]
+
+[ext_resource type="Script" path="res://Scripts/Model/ScreenResolution.gd" id="1_rk38i"]
+
+[resource]
+script = ExtResource("1_rk38i")
+width = 1366
+height = 768

--- a/Birthday-2024-Project/Resources/Video/1440x900.tres
+++ b/Birthday-2024-Project/Resources/Video/1440x900.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="ScreenResolution" load_steps=2 format=3 uid="uid://b3r8hjt7pd3dl"]
+
+[ext_resource type="Script" path="res://Scripts/Model/ScreenResolution.gd" id="1_ievcu"]
+
+[resource]
+script = ExtResource("1_ievcu")
+width = 1440
+height = 900

--- a/Birthday-2024-Project/Resources/Video/1920x1080.tres
+++ b/Birthday-2024-Project/Resources/Video/1920x1080.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="ScreenResolution" load_steps=2 format=3 uid="uid://c8jpl3lhgb7f6"]
+
+[ext_resource type="Script" path="res://Scripts/Model/ScreenResolution.gd" id="1_40gns"]
+
+[resource]
+script = ExtResource("1_40gns")
+width = 1920
+height = 1080

--- a/Birthday-2024-Project/ScenePrefabs/GameMaster.tscn
+++ b/Birthday-2024-Project/ScenePrefabs/GameMaster.tscn
@@ -1,11 +1,20 @@
-[gd_scene load_steps=3 format=3 uid="uid://c6xsrisrdefrq"]
+[gd_scene load_steps=7 format=3 uid="uid://c6xsrisrdefrq"]
 
 [ext_resource type="Script" path="res://Scripts/Game/GameMaster.gd" id="1_agon8"]
 [ext_resource type="Script" path="res://Scripts/Game/AudioController.gd" id="2_1oy3c"]
+[ext_resource type="Script" path="res://Scripts/Game/VideoController.gd" id="3_ayqci"]
+[ext_resource type="Resource" uid="uid://c8jpl3lhgb7f6" path="res://Resources/Video/1920x1080.tres" id="4_53h28"]
+[ext_resource type="Resource" uid="uid://b3r8hjt7pd3dl" path="res://Resources/Video/1440x900.tres" id="5_8a61i"]
+[ext_resource type="Resource" uid="uid://dth7hfnnen2p8" path="res://Resources/Video/1366x768.tres" id="6_rln2h"]
 
-[node name="GameMaster" type="Node2D" node_paths=PackedStringArray("audio_controller")]
+[node name="GameMaster" type="Node2D" node_paths=PackedStringArray("audio_controller", "video_controller")]
 script = ExtResource("1_agon8")
 audio_controller = NodePath("AudioController")
+video_controller = NodePath("VideoController")
 
 [node name="AudioController" type="Node2D" parent="."]
 script = ExtResource("2_1oy3c")
+
+[node name="VideoController" type="Node2D" parent="."]
+script = ExtResource("3_ayqci")
+resolutions = Array[Resource("res://Scripts/Model/ScreenResolution.gd")]([ExtResource("4_53h28"), ExtResource("5_8a61i"), ExtResource("6_rln2h")])

--- a/Birthday-2024-Project/ScenePrefabs/GameMaster.tscn
+++ b/Birthday-2024-Project/ScenePrefabs/GameMaster.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=3 format=3 uid="uid://c6xsrisrdefrq"]
+
+[ext_resource type="Script" path="res://Scripts/Game/GameMaster.gd" id="1_agon8"]
+[ext_resource type="Script" path="res://Scripts/Game/AudioController.gd" id="2_1oy3c"]
+
+[node name="GameMaster" type="Node2D" node_paths=PackedStringArray("audio_controller")]
+script = ExtResource("1_agon8")
+audio_controller = NodePath("AudioController")
+
+[node name="AudioController" type="Node2D" parent="."]
+script = ExtResource("2_1oy3c")

--- a/Birthday-2024-Project/ScenePrefabs/SettingsWindow.tscn
+++ b/Birthday-2024-Project/ScenePrefabs/SettingsWindow.tscn
@@ -91,9 +91,13 @@ popup/item_1/id = 2
 popup/item_2/text = "1366×768"
 popup/item_2/id = 1
 
-[node name="Audio" type="TabBar" parent="MarginContainer/Window/TabContainer" node_paths=PackedStringArray("music_sample_player", "sfx_sample_player", "fauna_sample_player")]
+[node name="Audio" type="TabBar" parent="MarginContainer/Window/TabContainer" node_paths=PackedStringArray("master_slider", "music_slider", "sfx_slider", "fauna_slider", "music_sample_player", "sfx_sample_player", "fauna_sample_player")]
 layout_mode = 2
 script = ExtResource("3_jxrfi")
+master_slider = NodePath("MarginContainer/Settings Container/Master Container/Master Slider")
+music_slider = NodePath("MarginContainer/Settings Container/Music Container/Music Slider")
+sfx_slider = NodePath("MarginContainer/Settings Container/SFX Container/SFX Slider")
+fauna_slider = NodePath("MarginContainer/Settings Container/Fauna Container/Fauna Slider")
 music_sample_player = NodePath("MusicSamplePlayer")
 sfx_sample_player = NodePath("SfxSamplePlayer")
 fauna_sample_player = NodePath("FaunaSamplePlayer")
@@ -193,8 +197,4 @@ text = "Close"
 
 [connection signal="item_selected" from="MarginContainer/Window/TabContainer/Video/MarginContainer/Settings Container/ScreenOptions" to="MarginContainer/Window/TabContainer/Video" method="on_screen_selected"]
 [connection signal="item_selected" from="MarginContainer/Window/TabContainer/Video/MarginContainer/Settings Container/ResolutionOptions" to="MarginContainer/Window/TabContainer/Video" method="on_resolution_selected"]
-[connection signal="value_changed" from="MarginContainer/Window/TabContainer/Audio/MarginContainer/Settings Container/Master Container/Master Slider" to="MarginContainer/Window/TabContainer/Audio" method="on_master_slider_value_changed"]
-[connection signal="value_changed" from="MarginContainer/Window/TabContainer/Audio/MarginContainer/Settings Container/Music Container/Music Slider" to="MarginContainer/Window/TabContainer/Audio" method="on_music_slider_value_changed"]
-[connection signal="value_changed" from="MarginContainer/Window/TabContainer/Audio/MarginContainer/Settings Container/SFX Container/SFX Slider" to="MarginContainer/Window/TabContainer/Audio" method="on_sfx_slider_value_changed"]
-[connection signal="value_changed" from="MarginContainer/Window/TabContainer/Audio/MarginContainer/Settings Container/Fauna Container/Fauna Slider" to="MarginContainer/Window/TabContainer/Audio" method="on_fauna_slider_value_changed"]
 [connection signal="button_up" from="MarginContainer/Window/Close Button" to="." method="on_close_clicked"]

--- a/Birthday-2024-Project/ScenePrefabs/SettingsWindow.tscn
+++ b/Birthday-2024-Project/ScenePrefabs/SettingsWindow.tscn
@@ -50,8 +50,8 @@ tab_alignment = 1
 [node name="Video" type="TabBar" parent="MarginContainer/Window/TabContainer" node_paths=PackedStringArray("window_options", "resolution_options")]
 layout_mode = 2
 script = ExtResource("2_y1ii8")
-window_options = NodePath("MarginContainer/Settings Container/WindowOptions")
-resolution_options = NodePath("MarginContainer/Settings Container/ResolutionOptions")
+window_options = NodePath("MarginContainer/Settings Container/WindowContainer/WindowOptions")
+resolution_options = NodePath("MarginContainer/Settings Container/ResolutionContainer/ResolutionOptions")
 
 [node name="MarginContainer" type="MarginContainer" parent="MarginContainer/Window/TabContainer/Video"]
 layout_mode = 1
@@ -68,7 +68,14 @@ theme_override_constants/margin_bottom = 5
 [node name="Settings Container" type="VBoxContainer" parent="MarginContainer/Window/TabContainer/Video/MarginContainer"]
 layout_mode = 2
 
-[node name="WindowOptions" type="OptionButton" parent="MarginContainer/Window/TabContainer/Video/MarginContainer/Settings Container"]
+[node name="WindowContainer" type="VBoxContainer" parent="MarginContainer/Window/TabContainer/Video/MarginContainer/Settings Container"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/Window/TabContainer/Video/MarginContainer/Settings Container/WindowContainer"]
+layout_mode = 2
+text = "Window Mode"
+
+[node name="WindowOptions" type="OptionButton" parent="MarginContainer/Window/TabContainer/Video/MarginContainer/Settings Container/WindowContainer"]
 layout_mode = 2
 item_count = 3
 selected = 0
@@ -79,7 +86,14 @@ popup/item_1/id = 1
 popup/item_2/text = "Windowed Borderless"
 popup/item_2/id = 2
 
-[node name="ResolutionOptions" type="OptionButton" parent="MarginContainer/Window/TabContainer/Video/MarginContainer/Settings Container"]
+[node name="ResolutionContainer" type="VBoxContainer" parent="MarginContainer/Window/TabContainer/Video/MarginContainer/Settings Container"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/Window/TabContainer/Video/MarginContainer/Settings Container/ResolutionContainer"]
+layout_mode = 2
+text = "Screen Resolution"
+
+[node name="ResolutionOptions" type="OptionButton" parent="MarginContainer/Window/TabContainer/Video/MarginContainer/Settings Container/ResolutionContainer"]
 layout_mode = 2
 
 [node name="Audio" type="TabBar" parent="MarginContainer/Window/TabContainer" node_paths=PackedStringArray("master_slider", "music_slider", "sfx_slider", "fauna_slider", "music_sample_player", "sfx_sample_player", "fauna_sample_player")]

--- a/Birthday-2024-Project/ScenePrefabs/SettingsWindow.tscn
+++ b/Birthday-2024-Project/ScenePrefabs/SettingsWindow.tscn
@@ -46,12 +46,11 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 tab_alignment = 1
-current_tab = 1
 
-[node name="Video" type="TabBar" parent="MarginContainer/Window/TabContainer" node_paths=PackedStringArray("resolution_options")]
-visible = false
+[node name="Video" type="TabBar" parent="MarginContainer/Window/TabContainer" node_paths=PackedStringArray("window_options", "resolution_options")]
 layout_mode = 2
 script = ExtResource("2_y1ii8")
+window_options = NodePath("MarginContainer/Settings Container/WindowOptions")
 resolution_options = NodePath("MarginContainer/Settings Container/ResolutionOptions")
 
 [node name="MarginContainer" type="MarginContainer" parent="MarginContainer/Window/TabContainer/Video"]
@@ -69,7 +68,7 @@ theme_override_constants/margin_bottom = 5
 [node name="Settings Container" type="VBoxContainer" parent="MarginContainer/Window/TabContainer/Video/MarginContainer"]
 layout_mode = 2
 
-[node name="ScreenOptions" type="OptionButton" parent="MarginContainer/Window/TabContainer/Video/MarginContainer/Settings Container"]
+[node name="WindowOptions" type="OptionButton" parent="MarginContainer/Window/TabContainer/Video/MarginContainer/Settings Container"]
 layout_mode = 2
 item_count = 3
 selected = 0
@@ -82,16 +81,9 @@ popup/item_2/id = 2
 
 [node name="ResolutionOptions" type="OptionButton" parent="MarginContainer/Window/TabContainer/Video/MarginContainer/Settings Container"]
 layout_mode = 2
-item_count = 3
-selected = 0
-popup/item_0/text = "1920x1080"
-popup/item_0/id = 0
-popup/item_1/text = "1440×900"
-popup/item_1/id = 2
-popup/item_2/text = "1366×768"
-popup/item_2/id = 1
 
 [node name="Audio" type="TabBar" parent="MarginContainer/Window/TabContainer" node_paths=PackedStringArray("master_slider", "music_slider", "sfx_slider", "fauna_slider", "music_sample_player", "sfx_sample_player", "fauna_sample_player")]
+visible = false
 layout_mode = 2
 script = ExtResource("3_jxrfi")
 master_slider = NodePath("MarginContainer/Settings Container/Master Container/Master Slider")
@@ -195,6 +187,4 @@ offset_bottom = 31.0
 grow_horizontal = 0
 text = "Close"
 
-[connection signal="item_selected" from="MarginContainer/Window/TabContainer/Video/MarginContainer/Settings Container/ScreenOptions" to="MarginContainer/Window/TabContainer/Video" method="on_screen_selected"]
-[connection signal="item_selected" from="MarginContainer/Window/TabContainer/Video/MarginContainer/Settings Container/ResolutionOptions" to="MarginContainer/Window/TabContainer/Video" method="on_resolution_selected"]
 [connection signal="button_up" from="MarginContainer/Window/Close Button" to="." method="on_close_clicked"]

--- a/Birthday-2024-Project/Scripts/Game/AudioController.gd
+++ b/Birthday-2024-Project/Scripts/Game/AudioController.gd
@@ -4,30 +4,30 @@ extends Node2D
 
 var _prefs: AudioPreferences
 
-const _fauna_bus: String = "Fauna"
-const _master_bus: String = "Master"
-const _music_bus: String = "Music"
-const _sfx_bus: String = "SFX"
+const _FAUNA_BUS: String = "Fauna"
+const _MASTER_BUS: String = "Master"
+const _MUSIC_BUS: String = "Music"
+const _SFX_BUS: String = "SFX"
 
 
 func set_fauna_volume(value: float):
 	_prefs.fauna = value
-	_set_bus_volume(value, _fauna_bus)
+	_set_bus_volume(value, _FAUNA_BUS)
 
 
 func set_master_volume(value: float):
 	_prefs.master = value
-	_set_bus_volume(value, _master_bus)
+	_set_bus_volume(value, _MASTER_BUS)
 
 
 func set_music_volume(value: float):
 	_prefs.music = value
-	_set_bus_volume(value, _music_bus)
+	_set_bus_volume(value, _MUSIC_BUS)
 
 
 func set_sfx_volume(value: float):
 	_prefs.sfx = value
-	_set_bus_volume(value, _sfx_bus)
+	_set_bus_volume(value, _SFX_BUS)
 
 
 func _apply_prefs():

--- a/Birthday-2024-Project/Scripts/Game/AudioController.gd
+++ b/Birthday-2024-Project/Scripts/Game/AudioController.gd
@@ -10,15 +10,6 @@ const _music_bus: String = "Music"
 const _sfx_bus: String = "SFX"
 
 
-func apply_prefs(prefs: UserPreferences):
-	var audio = prefs.audio;
-	
-	set_master_volume(audio.master)
-	set_music_volume(audio.music)
-	set_sfx_volume(audio.sfx)
-	set_fauna_volume(audio.fauna)
-
-
 func set_fauna_volume(value: float):
 	_prefs.fauna = value
 	_set_bus_volume(value, _fauna_bus)
@@ -37,6 +28,13 @@ func set_music_volume(value: float):
 func set_sfx_volume(value: float):
 	_prefs.sfx = value
 	_set_bus_volume(value, _sfx_bus)
+
+
+func _apply_prefs():
+	set_master_volume(_prefs.master)
+	set_music_volume(_prefs.music)
+	set_sfx_volume(_prefs.sfx)
+	set_fauna_volume(_prefs.fauna)
 
 
 func _set_bus_volume(value: float, bus_name: String):

--- a/Birthday-2024-Project/Scripts/Game/AudioController.gd
+++ b/Birthday-2024-Project/Scripts/Game/AudioController.gd
@@ -1,0 +1,47 @@
+class_name AudioController
+extends Node2D
+
+
+var _prefs: AudioPreferences
+
+const _fauna_bus: String = "Fauna"
+const _master_bus: String = "Master"
+const _music_bus: String = "Music"
+const _sfx_bus: String = "SFX"
+
+
+func apply_prefs(prefs: UserPreferences):
+	var audio = prefs.audio;
+	
+	set_master_volume(audio.master)
+	set_music_volume(audio.music)
+	set_sfx_volume(audio.sfx)
+	set_fauna_volume(audio.fauna)
+
+
+func set_fauna_volume(value: float):
+	_prefs.fauna = value
+	_set_bus_volume(value, _fauna_bus)
+
+
+func set_master_volume(value: float):
+	_prefs.master = value
+	_set_bus_volume(value, _master_bus)
+
+
+func set_music_volume(value: float):
+	_prefs.music = value
+	_set_bus_volume(value, _music_bus)
+
+
+func set_sfx_volume(value: float):
+	_prefs.sfx = value
+	_set_bus_volume(value, _sfx_bus)
+
+
+func _set_bus_volume(value: float, bus_name: String):
+	var db = log(clamp(value, 0.001, 1)) / log(10) * 20 # Convert to decibels
+	var bus_idx = AudioServer.get_bus_index(bus_name)
+	
+	AudioServer.set_bus_volume_db(bus_idx, db)
+

--- a/Birthday-2024-Project/Scripts/Game/GameMaster.gd
+++ b/Birthday-2024-Project/Scripts/Game/GameMaster.gd
@@ -12,6 +12,10 @@ var user_prefs: UserPreferences
 var _save_system: SaveSystem
 
 
+func save_preferences():
+	_save_system.save_user_preferences(user_prefs)
+
+
 func _apply_settings():
 	audio_controller._apply_prefs()
 	video_controller._apply_prefs()

--- a/Birthday-2024-Project/Scripts/Game/GameMaster.gd
+++ b/Birthday-2024-Project/Scripts/Game/GameMaster.gd
@@ -2,13 +2,13 @@ class_name GameMaster
 extends Node2D
 
 
+# Controllers
 @export var audio_controller: AudioController
 @export var video_controller: VideoController
 
 # State/Prefs
 var user_prefs: UserPreferences
 
-# Controllers
 var _save_system: SaveSystem
 
 

--- a/Birthday-2024-Project/Scripts/Game/GameMaster.gd
+++ b/Birthday-2024-Project/Scripts/Game/GameMaster.gd
@@ -3,6 +3,7 @@ extends Node2D
 
 
 @export var audio_controller: AudioController
+@export var video_controller: VideoController
 
 # State/Prefs
 var user_prefs: UserPreferences
@@ -12,13 +13,15 @@ var _save_system: SaveSystem
 
 
 func _apply_settings():
-	audio_controller.apply_prefs(user_prefs)
+	audio_controller._apply_prefs()
+	video_controller._apply_prefs()
 
 
 func _load_data():
 	user_prefs = _save_system.load_user_preferences()
 	
 	audio_controller._prefs = user_prefs.audio
+	video_controller._prefs = user_prefs.video
 
 
 #region Node

--- a/Birthday-2024-Project/Scripts/Game/GameMaster.gd
+++ b/Birthday-2024-Project/Scripts/Game/GameMaster.gd
@@ -1,0 +1,33 @@
+class_name GameMaster
+extends Node2D
+
+
+@export var audio_controller: AudioController
+
+# State/Prefs
+var user_prefs: UserPreferences
+
+# Controllers
+var _save_system: SaveSystem
+
+
+func _apply_settings():
+	audio_controller.apply_prefs(user_prefs)
+
+
+func _load_data():
+	user_prefs = _save_system.load_user_preferences()
+	
+	audio_controller._prefs = user_prefs.audio
+
+
+#region Node
+
+func _ready():
+	_save_system = SaveSystem.new("user://UserPref.pref")
+	
+	_load_data()
+	_apply_settings()
+
+
+#endregion Node

--- a/Birthday-2024-Project/Scripts/Game/SaveSystem.gd
+++ b/Birthday-2024-Project/Scripts/Game/SaveSystem.gd
@@ -1,0 +1,31 @@
+class_name SaveSystem
+
+
+var _config_path: String
+
+
+func load_user_preferences() -> UserPreferences:
+	var config = ConfigFile.new()
+	var err = config.load(_config_path)
+	
+	match err:
+		OK:
+			return UserPreferences.new(config)
+		ERR_FILE_NOT_FOUND:
+			return UserPreferences.new()
+		_:
+			printerr("Encountered error while loading user preferences: ", err)
+			return UserPreferences.new()
+
+
+func save_user_preferences():
+	var config = ConfigFile.new()
+	var err = config.save(_config_path)
+	
+	if err != OK:
+		printerr("Encountered error while saving user preferences: ", err)
+
+
+func _init(path: String):
+	_config_path = path
+

--- a/Birthday-2024-Project/Scripts/Game/SaveSystem.gd
+++ b/Birthday-2024-Project/Scripts/Game/SaveSystem.gd
@@ -18,8 +18,10 @@ func load_user_preferences() -> UserPreferences:
 			return UserPreferences.new()
 
 
-func save_user_preferences():
+func save_user_preferences(prefs: UserPreferences):
 	var config = ConfigFile.new()
+	prefs._save_config(config)
+	
 	var err = config.save(_config_path)
 	
 	if err != OK:

--- a/Birthday-2024-Project/Scripts/Game/VideoController.gd
+++ b/Birthday-2024-Project/Scripts/Game/VideoController.gd
@@ -1,0 +1,72 @@
+class_name VideoController
+extends Node2D
+
+
+@export var resolutions: Array[ScreenResolution] = []
+
+var _prefs: VideoPreferences
+
+
+func enable_fullscreen():
+	_prefs.window = VideoPreferences.WindowType.FULLSCREEN
+	
+	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN)
+	DisplayServer.window_set_flag(DisplayServer.WINDOW_FLAG_BORDERLESS, false)
+
+
+func enable_windowed():
+	_prefs.window = VideoPreferences.WindowType.WINDOWED
+	
+	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
+	DisplayServer.window_set_flag(DisplayServer.WINDOW_FLAG_BORDERLESS, false)
+	
+	_resize_window()
+
+
+func enable_windowed_borderless():
+	_prefs.window = VideoPreferences.WindowType.WINDOWED_BORDERLESS
+	
+	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_MAXIMIZED)
+	DisplayServer.window_set_flag(DisplayServer.WINDOW_FLAG_BORDERLESS, true)
+
+
+func set_resolution(res_idx: int):
+	if resolutions == null:
+		printerr("Available resolution is null")
+		return
+	
+	var len = resolutions.size()
+	
+	if res_idx < 0 or res_idx >= len:
+		printerr("Out-of-range for resolutions (", res_idx, "; len=", len, ")")
+		return
+	
+	var res = resolutions[res_idx]
+	_prefs.width = res.width
+	_prefs.height = res.height
+	
+	_resize_window()
+
+
+func _apply_prefs():
+	match _prefs.window:
+		VideoPreferences.WindowType.FULLSCREEN:
+			enable_fullscreen()
+		VideoPreferences.WindowType.WINDOWED:
+			enable_windowed()
+		VideoPreferences.WindowType.WINDOWED_BORDERLESS:
+			enable_windowed_borderless()
+		_:
+			printerr("Unknown window type for video preference: ", _prefs.window)
+
+
+func _resize_window():
+	if _prefs.window != VideoPreferences.WindowType.WINDOWED:
+		return
+	
+	var width = _prefs.width;
+	var height = _prefs.height;
+	
+	DisplayServer.window_set_size(Vector2i(width, height))
+	# TODO: Change position of window for best fit in screen.
+

--- a/Birthday-2024-Project/Scripts/Model/Prefs/AudioPreferences.gd
+++ b/Birthday-2024-Project/Scripts/Model/Prefs/AudioPreferences.gd
@@ -7,31 +7,31 @@ var master: float
 var music: float
 var sfx: float
 
-const _default_fauna: float = 0.5
-const _default_master: float = 1.0
-const _default_music: float = 0.5
-const _default_sfx: float = 0.5
-const _section_name: String = "audio"
+const _DEFAULT_FAUNA: float = 0.5
+const _DEFAULT_MASTER: float = 1.0
+const _DEFAULT_MUSIC: float = 0.5
+const _DEFAULT_SFX: float = 0.5
+const _SECTION_NAME: String = "audio"
 
 
 #region Preferences
 
 func _apply_config(config: ConfigFile):
-	if not config.has_section(_section_name):
+	if not config.has_section(_SECTION_NAME):
 		_apply_defaults()
 		return
 	
-	master = config.get_value(_section_name, "master", _default_master)
-	music = config.get_value(_section_name, "music", _default_music)
-	sfx = config.get_value(_section_name, "sfx", _default_sfx)
-	fauna = config.get_value(_section_name, "fauna", _default_fauna)
+	master = config.get_value(_SECTION_NAME, "master", _DEFAULT_MASTER)
+	music = config.get_value(_SECTION_NAME, "music", _DEFAULT_MUSIC)
+	sfx = config.get_value(_SECTION_NAME, "sfx", _DEFAULT_SFX)
+	fauna = config.get_value(_SECTION_NAME, "fauna", _DEFAULT_FAUNA)
 
 
 func _apply_defaults():
-	master = _default_master
-	music = _default_music
-	sfx = _default_sfx
-	fauna = _default_fauna
+	master = _DEFAULT_MASTER
+	music = _DEFAULT_MUSIC
+	sfx = _DEFAULT_SFX
+	fauna = _DEFAULT_FAUNA
 
 
 #endregion Preferences

--- a/Birthday-2024-Project/Scripts/Model/Prefs/AudioPreferences.gd
+++ b/Birthday-2024-Project/Scripts/Model/Prefs/AudioPreferences.gd
@@ -34,4 +34,11 @@ func _apply_defaults():
 	fauna = _DEFAULT_FAUNA
 
 
+func _save_config(config: ConfigFile):
+	config.set_value(_SECTION_NAME, "master", master)
+	config.set_value(_SECTION_NAME, "music", music)
+	config.set_value(_SECTION_NAME, "sfx", sfx)
+	config.set_value(_SECTION_NAME, "fauna", fauna)
+
+
 #endregion Preferences

--- a/Birthday-2024-Project/Scripts/Model/Prefs/AudioPreferences.gd
+++ b/Birthday-2024-Project/Scripts/Model/Prefs/AudioPreferences.gd
@@ -1,0 +1,37 @@
+class_name AudioPreferences
+extends Preferences
+
+
+var fauna: float
+var master: float
+var music: float
+var sfx: float
+
+const _default_fauna: float = 0.5
+const _default_master: float = 1.0
+const _default_music: float = 0.5
+const _default_sfx: float = 0.5
+const _section_name: String = "audio"
+
+
+#region Preferences
+
+func _apply_config(config: ConfigFile):
+	if not config.has_section(_section_name):
+		_apply_defaults()
+		return
+	
+	master = config.get_value(_section_name, "master", _default_master)
+	music = config.get_value(_section_name, "music", _default_music)
+	sfx = config.get_value(_section_name, "sfx", _default_sfx)
+	fauna = config.get_value(_section_name, "fauna", _default_fauna)
+
+
+func _apply_defaults():
+	master = _default_master
+	music = _default_music
+	sfx = _default_sfx
+	fauna = _default_fauna
+
+
+#endregion Preferences

--- a/Birthday-2024-Project/Scripts/Model/Prefs/Preferences.gd
+++ b/Birthday-2024-Project/Scripts/Model/Prefs/Preferences.gd
@@ -1,0 +1,17 @@
+class_name Preferences
+
+
+func _apply_config(config: ConfigFile):
+	pass
+
+
+func _apply_defaults():
+	pass
+
+
+func _init(config: ConfigFile = null):
+	if config == null:
+		_apply_defaults()
+	else:
+		_apply_config(config)
+

--- a/Birthday-2024-Project/Scripts/Model/Prefs/Preferences.gd
+++ b/Birthday-2024-Project/Scripts/Model/Prefs/Preferences.gd
@@ -15,3 +15,7 @@ func _init(config: ConfigFile = null):
 	else:
 		_apply_config(config)
 
+
+func _save_config(config: ConfigFile):
+	pass
+

--- a/Birthday-2024-Project/Scripts/Model/Prefs/UserPreferences.gd
+++ b/Birthday-2024-Project/Scripts/Model/Prefs/UserPreferences.gd
@@ -18,4 +18,9 @@ func _apply_defaults():
 	video = VideoPreferences.new()
 
 
+func _save_config(config: ConfigFile):
+	audio._save_config(config)
+	video._save_config(config)
+
+
 #endregion Preferences

--- a/Birthday-2024-Project/Scripts/Model/Prefs/UserPreferences.gd
+++ b/Birthday-2024-Project/Scripts/Model/Prefs/UserPreferences.gd
@@ -1,0 +1,18 @@
+class_name UserPreferences
+extends Preferences
+
+
+var audio: AudioPreferences
+
+
+#region Preferences
+
+func _apply_config(config: ConfigFile):
+	audio = AudioPreferences.new(config)
+
+
+func _apply_defaults():
+	audio = AudioPreferences.new()
+
+
+#endregion Preferences

--- a/Birthday-2024-Project/Scripts/Model/Prefs/UserPreferences.gd
+++ b/Birthday-2024-Project/Scripts/Model/Prefs/UserPreferences.gd
@@ -3,16 +3,19 @@ extends Preferences
 
 
 var audio: AudioPreferences
+var video: VideoPreferences
 
 
 #region Preferences
 
 func _apply_config(config: ConfigFile):
 	audio = AudioPreferences.new(config)
+	video = VideoPreferences.new(config)
 
 
 func _apply_defaults():
 	audio = AudioPreferences.new()
+	video = VideoPreferences.new()
 
 
 #endregion Preferences

--- a/Birthday-2024-Project/Scripts/Model/Prefs/VideoPreferences.gd
+++ b/Birthday-2024-Project/Scripts/Model/Prefs/VideoPreferences.gd
@@ -1,0 +1,41 @@
+class_name VideoPreferences
+extends Preferences
+
+
+var height: int
+var width: int
+var window: WindowType
+
+const _DEFAULT_HEIGHT: int = 1080
+const _DEFAULT_WIDTH: int = 1920
+const _DEFAULT_WINDOW: WindowType = WindowType.FULLSCREEN
+const _SECTION_NAME: String = "video"
+
+
+#region Preferences
+
+func _apply_config(config: ConfigFile):
+	if not config.has_section(_SECTION_NAME):
+		_apply_defaults()
+		return
+	
+	width = config.get_value(_SECTION_NAME, "width", _DEFAULT_WIDTH)
+	height = config.get_value(_SECTION_NAME, "height", _DEFAULT_HEIGHT)
+	window = config.get_value(_SECTION_NAME, "window", _DEFAULT_WINDOW)
+
+
+func _apply_defaults():
+	width = _DEFAULT_WIDTH
+	height = _DEFAULT_HEIGHT
+	window = _DEFAULT_WINDOW
+
+
+#endregion Preferences
+
+enum WindowType
+{
+	FULLSCREEN = 0,
+	WINDOWED = 1,
+	WINDOWED_BORDERLESS = 2,
+}
+

--- a/Birthday-2024-Project/Scripts/Model/Prefs/VideoPreferences.gd
+++ b/Birthday-2024-Project/Scripts/Model/Prefs/VideoPreferences.gd
@@ -30,6 +30,12 @@ func _apply_defaults():
 	window = _DEFAULT_WINDOW
 
 
+func _save_config(config: ConfigFile):
+	config.set_value(_SECTION_NAME, "width", width)
+	config.set_value(_SECTION_NAME, "height", height)
+	config.set_value(_SECTION_NAME, "window", window)
+
+
 #endregion Preferences
 
 enum WindowType

--- a/Birthday-2024-Project/Scripts/Model/ScreenResolution.gd
+++ b/Birthday-2024-Project/Scripts/Model/ScreenResolution.gd
@@ -1,0 +1,6 @@
+class_name ScreenResolution
+extends Resource
+
+
+@export var width: int
+@export var height: int

--- a/Birthday-2024-Project/Scripts/UI/Settings/AudioSettingsControl.gd
+++ b/Birthday-2024-Project/Scripts/UI/Settings/AudioSettingsControl.gd
@@ -2,6 +2,12 @@ class_name AudioSettingsControl
 extends Control
 
 
+@export_group("UI Elements")
+@export var master_slider: Slider
+@export var music_slider: Slider
+@export var sfx_slider: Slider
+@export var fauna_slider: Slider
+
 @export_group("Audio Players")
 @export var music_sample_player: AudioStreamPlayer2D # TODO: DELETE WHEN NO LONGER NEEDED
 @export var sfx_sample_player: AudioStreamPlayer2D
@@ -12,31 +18,35 @@ extends Control
 @export var fauna_samples: AudioSamples
 @export var tone_sample: AudioStream # TODO: DELETE WHEN NO LONGER NEEDED
 
+var _gm: GameMaster
 
-func on_fauna_slider_value_changed(value: float):
-	_change_bus_volume(value, "Fauna")
+
+func revert_changes():
+	var audio = _gm.user_prefs.audio
+	
+	master_slider.value = audio.master
+	music_slider.value = audio.music
+	sfx_slider.value = audio.sfx
+	fauna_slider.value = audio.fauna
+
+
+func _on_fauna_slider_value_changed(value: float):
+	_gm.audio_controller.set_fauna_volume(value)
 	_play_sample(fauna_samples.get_random_sample(), fauna_sample_player)
 
 
-func on_master_slider_value_changed(value: float):
-	_change_bus_volume(value, "Master")
+func _on_master_slider_value_changed(value: float):
+	_gm.audio_controller.set_master_volume(value)
 
 
-func on_music_slider_value_changed(value: float):
-	_change_bus_volume(value, "Music")
+func _on_music_slider_value_changed(value: float):
+	_gm.audio_controller.set_music_volume(value)
 	_play_sample(tone_sample, music_sample_player) # TODO: Remove when BGM is added.
 
 
-func on_sfx_slider_value_changed(value: float):
-	_change_bus_volume(value, "SFX")
+func _on_sfx_slider_value_changed(value: float):
+	_gm.audio_controller.set_sfx_volume(value)
 	_play_sample(sfx_samples.get_random_sample(), sfx_sample_player)
-
-
-func _change_bus_volume(value: float, bus_name: String):
-	var db = log(clamp(value, 0.001, 1)) / log(10) * 20 # Convert to decibels
-	var bus_idx = AudioServer.get_bus_index(bus_name)
-	
-	AudioServer.set_bus_volume_db(bus_idx, db)
 
 
 func _play_sample(stream: AudioStream, player: AudioStreamPlayer2D):
@@ -50,10 +60,14 @@ func _play_sample(stream: AudioStream, player: AudioStreamPlayer2D):
 #region Node
 
 func _ready():
-	_change_bus_volume(1, "Master")
-	_change_bus_volume(0.5, "Music")
-	_change_bus_volume(0.5, "SFX")
-	_change_bus_volume(0.5, "Fauna")
+	_gm = get_node("/root/GlobalGameMaster")
+	
+	revert_changes()
+	
+	master_slider.value_changed.connect(_on_master_slider_value_changed)
+	music_slider.value_changed.connect(_on_music_slider_value_changed)
+	sfx_slider.value_changed.connect(_on_sfx_slider_value_changed)
+	fauna_slider.value_changed.connect(_on_fauna_slider_value_changed)
 
 
 #endregion Node

--- a/Birthday-2024-Project/Scripts/UI/Settings/SettingsWindow.gd
+++ b/Birthday-2024-Project/Scripts/UI/Settings/SettingsWindow.gd
@@ -2,9 +2,20 @@ class_name SettingsWindow
 extends Control
 
 
+var _gm: GameMaster
+
 signal close_settings_window
 
 
 func on_close_clicked():
+	_gm.save_preferences()
 	close_settings_window.emit()
 
+
+#region Node
+
+func _ready():
+	_gm = get_node("/root/GlobalGameMaster")
+
+
+#endregion Node

--- a/Birthday-2024-Project/Scripts/UI/Settings/VideoSettingsControl.gd
+++ b/Birthday-2024-Project/Scripts/UI/Settings/VideoSettingsControl.gd
@@ -7,6 +7,7 @@ extends Control
 
 var _gm: GameMaster
 
+const _CUSTOM_OPTION_ID: int = 999
 const _RESOLUTION_FORMAT: String = "%dx%d"
 
 
@@ -14,8 +15,12 @@ func revert_changes():
 	var video = _gm.user_prefs.video
 	
 	# Handle window options
-	window_options.select(video.window)
-	resolution_options.disabled = video.window != VideoPreferences.WindowType.WINDOWED
+	if video.window < window_options.item_count:
+		window_options.select(video.window)
+		resolution_options.disabled = video.window != VideoPreferences.WindowType.WINDOWED
+	else:
+		resolution_options.disabled = true
+		_add_and_select_custom(window_options)
 	
 	# Handle resolution options
 	var resolutions = _gm.video_controller.resolutions
@@ -33,12 +38,20 @@ func revert_changes():
 		resolution_options.select(i - 1)
 	
 	if not using_preset:
-		printerr("Video prefernces are using an unavailable screen resolution")
-		# TODO: Handle this case.
+		_add_and_select_custom(resolution_options)
+
+
+func _add_and_select_custom(options: OptionButton):
+	options.add_item("Custom", _CUSTOM_OPTION_ID)
+	
+	var idx = options.get_item_index(_CUSTOM_OPTION_ID)
+	options.selected = idx
+	options.set_item_disabled(idx, true)
 
 
 func _on_resolution_selected(index: int):
 	_gm.video_controller.set_resolution(index)
+	_remove_custom(resolution_options)
 
 
 func _on_window_selected(index: int):
@@ -54,6 +67,15 @@ func _on_window_selected(index: int):
 			_gm.video_controller.enable_windowed_borderless()
 		_:
 			printerr("Unhandled screen type selected")
+	
+	_remove_custom(window_options)
+
+
+func _remove_custom(options: OptionButton):
+	var idx = options.get_item_index(_CUSTOM_OPTION_ID)
+	
+	if idx >= 0:
+		options.remove_item(idx)
 
 
 #region Node

--- a/Birthday-2024-Project/Scripts/UI/Settings/VideoSettingsControl.gd
+++ b/Birthday-2024-Project/Scripts/UI/Settings/VideoSettingsControl.gd
@@ -2,69 +2,78 @@ class_name VideoSettingsControl
 extends Control
 
 
+@export var window_options: OptionButton
 @export var resolution_options: OptionButton
-var _height: int = 1080
-var _width: int = 1920
+
+var _gm: GameMaster
+
+const _RESOLUTION_FORMAT: String = "%dx%d"
 
 
-# TODO: Most of the logic in this class ought to be moved to a class that is
-#       dedicated to handling settings. (e.g. On game launch)
+func revert_changes():
+	var video = _gm.user_prefs.video
+	
+	# Handle window options
+	window_options.select(video.window)
+	resolution_options.disabled = video.window != VideoPreferences.WindowType.WINDOWED
+	
+	# Handle resolution options
+	var resolutions = _gm.video_controller.resolutions
+	var using_preset = false # Assume not using an available resolution
+	var i = 0
+	
+	while not using_preset and i < resolutions.size():
+		var res = resolutions[i]
+		i = i + 1
+		
+		if res.width != video.width or res.height != video.height:
+			continue
+		
+		using_preset = true
+		resolution_options.select(i - 1)
+	
+	if not using_preset:
+		printerr("Video prefernces are using an unavailable screen resolution")
+		# TODO: Handle this case.
 
-func on_screen_selected(index: int):
+
+func _on_resolution_selected(index: int):
+	_gm.video_controller.set_resolution(index)
+
+
+func _on_window_selected(index: int):
 	match index:
-		0:
-			_enable_fullscreen()
-		1:
-			_enable_windowed()
-		2:
-			_enable_windowed_borderless()
-
-
-func on_resolution_selected(index: int):
-	match index:
-		0:
-			_resize_window(1920, 1080)
-		1:
-			_resize_window(1440, 900)
-		2:
-			_resize_window(1366, 768)
-
-
-func _enable_fullscreen():
-	resolution_options.disabled = true
-	
-	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN)
-	DisplayServer.window_set_flag(DisplayServer.WINDOW_FLAG_BORDERLESS, false)
-
-
-func _enable_windowed():
-	resolution_options.disabled = false
-	
-	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
-	DisplayServer.window_set_flag(DisplayServer.WINDOW_FLAG_BORDERLESS, false)
-	
-	_resize_window(_width, _height)
-
-
-func _enable_windowed_borderless():
-	resolution_options.disabled = true
-	
-	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_MAXIMIZED)
-	DisplayServer.window_set_flag(DisplayServer.WINDOW_FLAG_BORDERLESS, true)
-
-
-func _resize_window(width: int, height: int):
-	_width = width;
-	_height = height;
-	
-	DisplayServer.window_set_size(Vector2i(width, height))
-	# TODO: Change position of window for best fit in screen.
+		VideoPreferences.WindowType.FULLSCREEN:
+			resolution_options.disabled = true
+			_gm.video_controller.enable_fullscreen()
+		VideoPreferences.WindowType.WINDOWED:
+			resolution_options.disabled = false
+			_gm.video_controller.enable_windowed()
+		VideoPreferences.WindowType.WINDOWED_BORDERLESS:
+			resolution_options.disabled = true
+			_gm.video_controller.enable_windowed_borderless()
+		_:
+			printerr("Unhandled screen type selected")
 
 
 #region Node
 
 func _ready():
-	_enable_fullscreen()
+	_gm = get_node("/root/GlobalGameMaster")
+	
+	# Setup resolution options
+	var resolutions = _gm.video_controller.resolutions
+	
+	for i in range(resolutions.size()):
+		var res = resolutions[i]
+		
+		resolution_options.add_item(_RESOLUTION_FORMAT % [res.width, res.height], i)
+	
+	revert_changes()
+	
+	# Connect listeners
+	window_options.item_selected.connect(_on_window_selected)
+	resolution_options.item_selected.connect(_on_resolution_selected)
 
 
 #endregion Node

--- a/Birthday-2024-Project/project.godot
+++ b/Birthday-2024-Project/project.godot
@@ -19,6 +19,10 @@ config/icon="res://icon.svg"
 
 buses/default_bus_layout="res://Resources/Audio/audio_bus.tres"
 
+[autoload]
+
+GlobalGameMaster="*res://ScenePrefabs/GameMaster.tscn"
+
 [display]
 
 window/size/viewport_width=1920


### PR DESCRIPTION
# Description

Adds a global game master node that holds global data and has controllers for managing that data. Also adds a save system that is at present able to save and load user data and reworks the settings window around the new system.

## Related issue(s)

https://github.com/Saplings-Projects/Birthday-2024/issues/22

## List of changes

### Added
- Script and resources for screen resolution options
- Scripts for user preferences
- Script for a save system for saving and loading data
- Controllers for video and audio settings
- `GameMaster` script and global singleton
- Labels for video settings

### Changed
- Settings window now relies on controllers in global game master for applying settings
- Screen resolution options are now based on a `ScreenResolution` resource array from game master's video controller

## Tests

None

## Additional notes

In the video settings tab, if a setting is not available that was loaded from the preferences, then a "Custom" option is now added to the option button until the player selects a valid option. This may be tested by opening the user preferences file on disk and changing the resolution to one that is not available.
