### PR TITLE
back button signal meant for main menu

### DIFF
--- a/Birthday-2024-Project/ScenePrefabs/MainMenuUiManager.tscn
+++ b/Birthday-2024-Project/ScenePrefabs/MainMenuUiManager.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://gfva2owqvlhw"]
+[gd_scene load_steps=8 format=3 uid="uid://gfva2owqvlhw"]
 
 [ext_resource type="Script" path="res://Scripts/UI/MainMenu/MainMenuUiManager.gd" id="1_lofx7"]
 [ext_resource type="Script" path="res://Scripts/UI/MainMenu/MainMenuStartScreen.gd" id="2_n7aum"]
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://btcp1sgcebsyi" path="res://ScenePrefabs/SettingsWindow.tscn" id="3_ukswp"]
 [ext_resource type="Script" path="res://Scripts/UI/MainMenu/States/MainMenuUiStartState.gd" id="3_vnjds"]
 [ext_resource type="PackedScene" uid="uid://lma3uuskmlpo" path="res://ScenePrefabs/CampaignLevelSelectMenu.tscn" id="4_o3atr"]
+[ext_resource type="PackedScene" uid="uid://c6xsrisrdefrq" path="res://ScenePrefabs/GameMaster.tscn" id="7_jtwva"]
 
 [node name="MainMenuUiManager" type="CanvasLayer" node_paths=PackedStringArray("settings_window", "start_screen", "campaign_select", "campaign_levels", "start_state")]
 script = ExtResource("1_lofx7")
@@ -116,6 +117,8 @@ offset_right = 40.0
 offset_bottom = 40.0
 script = ExtResource("3_vnjds")
 
+[node name="GameMaster" parent="." instance=ExtResource("7_jtwva")]
+
 [connection signal="back_to_main_menu" from="CampaignSelectMenu" to="States/MainMenuUiStartState" method="_on_back_to_main_menu_clicked"]
 [connection signal="exit_game" from="CampaignSelectMenu" to="States/MainMenuUiStartState" method="_on_exit_clicked"]
 [connection signal="open_campaign_levels" from="CampaignSelectMenu" to="States/MainMenuUiStartState" method="_on_campaign_levels_clicked"]
@@ -126,3 +129,4 @@ script = ExtResource("3_vnjds")
 [connection signal="open_settings_window" from="CampaignLevelSelectMenu" to="States/MainMenuUiStartState" method="_on_settings_clicked"]
 [connection signal="play" from="CampaignLevelSelectMenu" to="States/MainMenuUiStartState" method="_on_level_selected"]
 [connection signal="close_settings_window" from="SettingsWindow" to="." method="hide_settings_window"]
+[connection signal="back_campaign" from="GameMaster" to="." method="show_campaign_levels"]

--- a/Birthday-2024-Project/Scripts/Game/GameMaster.gd
+++ b/Birthday-2024-Project/Scripts/Game/GameMaster.gd
@@ -11,6 +11,8 @@ var user_prefs: UserPreferences
 
 var _save_system: SaveSystem
 
+signal back_campaign
+
 
 func save_preferences():
 	_save_system.save_user_preferences(user_prefs)
@@ -26,6 +28,11 @@ func _load_data():
 	
 	audio_controller._prefs = user_prefs.audio
 	video_controller._prefs = user_prefs.video
+
+
+func back_to_campaign_levels():
+	get_tree().change_scene_to_file("res://MainScenes/main_menu.tscn")
+	back_campaign.emit()
 
 
 #region Node

--- a/Birthday-2024-Project/Scripts/Game/States/GamePlayState.gd
+++ b/Birthday-2024-Project/Scripts/Game/States/GamePlayState.gd
@@ -1,12 +1,13 @@
 class_name GamePlayState
 extends GameState
 
+var _gm: GameMaster
 
 func reset_puzzle():
 	get_tree().reload_current_scene()
 
 func back_to_menu():
-	get_tree().change_scene_to_file("res://MainScenes/main_menu.tscn")#TODO remember where to go back (campaign or saplings' levels and go there)
+	_gm.back_to_campaign_levels()
 
 func skip_puzzle():
 	print("skip_puzzle is not fully implemented", self)
@@ -36,5 +37,8 @@ func exit_state():
 func update_state():
 	pass
 
+
+func _ready():
+	_gm = get_node("/root/GlobalGameMaster")
 
 #endregion GameState

--- a/Birthday-2024-Project/Scripts/Game/States/GameWinState.gd
+++ b/Birthday-2024-Project/Scripts/Game/States/GameWinState.gd
@@ -2,6 +2,9 @@ class_name GameWinState
 extends GameState
 
 
+var _gm: GameMaster
+
+
 func next_puzzle():
 	print("next_puzzle is not fully implemented", self)
 	reset_puzzle() # TODO: DELETE THIS WHEN NO LONGER NEEDED.
@@ -12,7 +15,7 @@ func reset_puzzle():
 
 
 func back_to_menu():
-	get_tree().change_scene_to_file("res://MainScenes/main_menu.tscn")#TODO remember where to go back (campaign or saplings' levels and go there)
+	_gm.back_to_campaign_levels()
 
 
 #region GameState
@@ -28,6 +31,10 @@ func exit_state():
 
 func update_state():
 	pass # Do nothing
+
+
+func _ready():
+	_gm = get_node("/root/GlobalGameMaster")
 
 
 #endregion GameState

--- a/Birthday-2024-Project/Scripts/UI/MainMenu/States/MainMenuUiStartState.gd
+++ b/Birthday-2024-Project/Scripts/UI/MainMenu/States/MainMenuUiStartState.gd
@@ -26,6 +26,7 @@ func _on_settings_clicked():
 
 
 func _on_campaign_levels_clicked():
+	print("asd")
 	_ui_manager.show_campaign_levels()
 
 
@@ -55,6 +56,7 @@ func enter_state():
 		return
 	
 	_state = state
+	
 	
 	_ui_manager.show_start_screen()
 	

--- a/Birthday-2024-Project/Scripts/UI/MainMenu/States/MainMenuUiStartState.gd
+++ b/Birthday-2024-Project/Scripts/UI/MainMenu/States/MainMenuUiStartState.gd
@@ -26,7 +26,6 @@ func _on_settings_clicked():
 
 
 func _on_campaign_levels_clicked():
-	print("asd")
 	_ui_manager.show_campaign_levels()
 
 


### PR DESCRIPTION
# Description

Connected "Back" buttons in main_level to script in autoloader GameMaster to make it go back to Level Select instead of Mani Menu

## Related issue(s)

https://github.com/Saplings-Projects/Birthday-2024/issues/27

## List of changes

A more detailed list of the changes.
- added GameMaster node to Main Menu
- created back_to_campaign_levels() function


## Additional notes

Need help with connection. back_campaign signal is being sent by GameMaster and scene is changed but the show_campaign_levels() is not called
