### PR TITLE
Pieces follow the mouse and lock into the grid more smoothly

### DIFF
--- a/Birthday-2024-Project/Scripts/GameManager.gd
+++ b/Birthday-2024-Project/Scripts/GameManager.gd
@@ -171,14 +171,19 @@ func _rotate_held_piece():
 		_reset_settled()
 		remaining_settle_delay = held_piece.ROTATION_ANIMATION_DURATION
 
+func _mouse_has_moved() -> bool:
+	var mouse_position : Vector2 = get_global_mouse_position()
+	var mouse_distance_moved : float = (mouse_position - previous_mouse_position).length()
+	previous_mouse_position = mouse_position
+	return mouse_distance_moved > 0.01
+
 func _get_held_piece_grid_origin() -> Vector2i:
 	return grid.PositionToGridCoordinate(held_piece.GetOriginCellPosition())
 
 func _do_held_piece_settle(delta):
 	var mouse_position : Vector2 = get_global_mouse_position()
-	var mouse_distance_moved : float = (mouse_position - previous_mouse_position).length()
 	var mouse_grid_pos : Vector2i = grid.PositionToGridCoordinate(mouse_position)
-	if (mouse_distance_moved > 0.1 and mouse_grid_pos != previous_mouse_grid_pos) or grid.CheckIfOffGridPos(mouse_position):
+	if (_mouse_has_moved() and mouse_grid_pos != previous_mouse_grid_pos) or grid.CheckIfOffGridPos(mouse_position):
 		_reset_settled()
 		held_piece.cancel_movement_tween()
 		previous_mouse_position = mouse_position

--- a/Birthday-2024-Project/Scripts/GameManager.gd
+++ b/Birthday-2024-Project/Scripts/GameManager.gd
@@ -175,7 +175,7 @@ func _mouse_has_moved() -> bool:
 	var mouse_position : Vector2 = get_global_mouse_position()
 	var mouse_distance_moved : float = (mouse_position - previous_mouse_position).length()
 	previous_mouse_position = mouse_position
-	return mouse_distance_moved > 0.01
+	return mouse_distance_moved > 0.01 # Has the mouse position changed beyond floating point errors?
 
 func _get_held_piece_grid_origin() -> Vector2i:
 	return grid.PositionToGridCoordinate(held_piece.GetOriginCellPosition())

--- a/Birthday-2024-Project/Scripts/GameManager.gd
+++ b/Birthday-2024-Project/Scripts/GameManager.gd
@@ -22,8 +22,10 @@ extends Node2D
 @export var debug_setupData : LevelSetup
 
 var held_piece: PieceLogic
+var held_piece_cell: int
 var held_piece_settled: bool
 var previous_mouse_position: Vector2
+var previous_mouse_grid_pos: Vector2i
 var remaining_settle_delay: float
 var overPieceLibrary : bool
 var placing_piece: bool #Track when _do_place_held_piece is running and prevent rotation
@@ -68,7 +70,7 @@ func _switch_state(state: GameState):
 	state_changed_event.emit(state)
 
 
-func on_piece_clicked(clicked_piece: PieceLogic):
+func on_piece_clicked(clicked_piece: PieceLogic, clicked_cell: int):
 	if not _can_interact or held_piece != null:
 		return
 	if _current_state == play_state:
@@ -79,6 +81,7 @@ func on_piece_clicked(clicked_piece: PieceLogic):
 		return
 	
 	held_piece = clicked_piece
+	held_piece_cell = clicked_cell
 	
 	# move to the forefront
 	grid.move_child(grid.get_child(held_piece.get_index()), -1)
@@ -134,18 +137,25 @@ func _remove_occupied_cells(piece: PieceLogic):
 		return
 	grid.RemovePieceByCoordinates(piece.placed_grid_position)
 
+func _get_held_piece_target_vector() -> Vector2:
+	var target_position: Vector2 = get_global_mouse_position()
+	if not grid.CheckIfOffGridPos(target_position):
+		target_position = grid.GridCoordinateToPosition(grid.PositionToGridCoordinate(target_position))
+	return held_piece.target_vector(target_position, held_piece_cell)
+	
+func _get_held_piece_target_origin() -> Vector2:
+	return held_piece.GetOriginCellPosition() + _get_held_piece_target_vector()
+
 func _held_piece_towards_cursor(delta):
 	if held_piece_settled:
 		return
 	
-	var target_position: Vector2 = get_global_mouse_position()
-	#target_position -= held_piece.pivot_offset
-	var held_piece_to_mouse: Vector2 = target_position - held_piece.global_position
+	var held_piece_to_mouse: Vector2 = _get_held_piece_target_vector()
 	var held_piece_to_mouse_distance: float = held_piece_to_mouse.length()
 	
 	var distance_step: float = (held_piece_flat_speed + held_piece_distance_speed * held_piece_to_mouse_distance) * delta
 	if distance_step > held_piece_to_mouse_distance:
-		held_piece.global_position = target_position
+		held_piece.global_position += held_piece_to_mouse
 		return
 	held_piece.global_position += held_piece_to_mouse.normalized() * distance_step
 
@@ -154,11 +164,12 @@ func _rotate_held_piece():
 		held_piece.rotate_clockwise()
 		held_piece.play_rotate_audio()
 		_reset_settled()
+		remaining_settle_delay = held_piece.ROTATION_ANIMATION_DURATION
 	elif Input.is_action_just_pressed("RotateAnticlockwise"):
 		held_piece.rotate_anticlockwise()
 		held_piece.play_rotate_audio()
 		_reset_settled()
-
+		remaining_settle_delay = held_piece.ROTATION_ANIMATION_DURATION
 
 func _get_held_piece_grid_origin() -> Vector2i:
 	return grid.PositionToGridCoordinate(held_piece.GetOriginCellPosition())
@@ -166,18 +177,22 @@ func _get_held_piece_grid_origin() -> Vector2i:
 func _do_held_piece_settle(delta):
 	var mouse_position : Vector2 = get_global_mouse_position()
 	var mouse_distance_moved : float = (mouse_position - previous_mouse_position).length()
-	if mouse_distance_moved > 0.1:
+	var mouse_grid_pos : Vector2i = grid.PositionToGridCoordinate(mouse_position)
+	if (mouse_distance_moved > 0.1 and mouse_grid_pos != previous_mouse_grid_pos) or grid.CheckIfOffGridPos(mouse_position):
 		_reset_settled()
 		held_piece.cancel_movement_tween()
 		previous_mouse_position = mouse_position
+		previous_mouse_grid_pos = mouse_grid_pos
 	else:
 		if held_piece_settled:
 			return
 		remaining_settle_delay -= delta
 		if remaining_settle_delay <= 0:
 			held_piece_settled = true
-			var held_piece_grid_origin : Vector2i = _get_held_piece_grid_origin()
-			if grid.CheckLegalToPlace(held_piece) == false:
+			var target_origin : Vector2 = _get_held_piece_target_origin()
+			var held_piece_grid_origin : Vector2i = grid.PositionToGridCoordinate(target_origin)
+			#if grid.CheckLegalToPlace(held_piece, target_origin) == false:
+			if grid.CheckIfOffGridPos(mouse_position):
 				return
 			var settle_position : Vector2 = _held_piece_placed_position(held_piece_grid_origin)
 			held_piece.movement_tween_to(settle_position, held_piece_settle_animation_duration)

--- a/Birthday-2024-Project/Scripts/GameManager.gd
+++ b/Birthday-2024-Project/Scripts/GameManager.gd
@@ -161,12 +161,12 @@ func _held_piece_towards_cursor(delta):
 
 func _rotate_held_piece():
 	if Input.is_action_just_pressed("RotateClockwise"):
-		held_piece.rotate_clockwise()
+		held_piece.rotate_clockwise(held_piece_cell)
 		held_piece.play_rotate_audio()
 		_reset_settled()
 		remaining_settle_delay = held_piece.ROTATION_ANIMATION_DURATION
 	elif Input.is_action_just_pressed("RotateAnticlockwise"):
-		held_piece.rotate_anticlockwise()
+		held_piece.rotate_anticlockwise(held_piece_cell)
 		held_piece.play_rotate_audio()
 		_reset_settled()
 		remaining_settle_delay = held_piece.ROTATION_ANIMATION_DURATION
@@ -182,10 +182,12 @@ func _get_held_piece_grid_origin() -> Vector2i:
 
 func _do_held_piece_settle(delta):
 	var mouse_position : Vector2 = get_global_mouse_position()
+	var mouse_has_moved : bool = _mouse_has_moved()
 	var mouse_grid_pos : Vector2i = grid.PositionToGridCoordinate(mouse_position)
-	if (_mouse_has_moved() and mouse_grid_pos != previous_mouse_grid_pos) or grid.CheckIfOffGridPos(mouse_position):
+	if (mouse_has_moved and mouse_grid_pos != previous_mouse_grid_pos) or grid.CheckIfOffGridPos(mouse_position):
 		_reset_settled()
-		held_piece.cancel_movement_tween()
+		if mouse_has_moved:
+			held_piece.cancel_movement_tween()
 		previous_mouse_position = mouse_position
 		previous_mouse_grid_pos = mouse_grid_pos
 	else:

--- a/Birthday-2024-Project/Scripts/GridLogic.gd
+++ b/Birthday-2024-Project/Scripts/GridLogic.gd
@@ -281,6 +281,14 @@ func CheckIfOffGrid(piece : PieceLogic) -> bool:
 	#all squares are outside the grid map
 	return true
 
+func CheckIfOffGridPos(pos: Vector2) -> bool:
+	var gridCoords : Vector2i = PositionToGridCoordinate(pos)
+	var spaceStatus : GridSpaceInfo = GetGridSpace(gridCoords)
+	#is out of max bounds
+	if spaceStatus != null and spaceStatus.currentStatus != GridSpaceStatus.CLOSED:
+			return false
+	return true
+
 func CheckIfOutsideSafeZone(piece : PieceLogic) -> bool:
 	# offset by grid centering
 	var pieceCoords : Vector2i = PositionToGridCoordinate(piece.GetOriginCellPosition() + global_position - gridCenterOffset)
@@ -323,6 +331,7 @@ func RemovePieceByCoordinates(gridCoord : Vector2i) -> PieceLogic:
 func RemovePieceByPosition(inputPosition : Vector2) -> PieceLogic:
 	var gridPos : Vector2i = PositionToGridCoordinate(inputPosition)
 	return RemovePieceByCoordinates(gridPos)
+
 
 ###############################################################################
 

--- a/Birthday-2024-Project/Scripts/PieceLogic.gd
+++ b/Birthday-2024-Project/Scripts/PieceLogic.gd
@@ -8,6 +8,7 @@ const GAME_MANAGER_NODE_PATH = "/root/MainLevel/GameManager"
 const ROTATION_ANIMATION_DURATION: float = 0.35 # Number of seconds a piece takes to rotate
 const RETURN_ANIMATION_DURATION: float = 0.5 # Number of seconds a piece takes to return to it's return position when dropped
 const PLACED_ANIMATION_DURATION: float = 0.2 # Number of seconds a piece take to move into it's placed position
+const NO_CELL_CLICKED: int = -1
 
 @export_multiline var pieceShape : String
 @export var isBlocker : bool
@@ -260,7 +261,7 @@ func _input(event):
 	if event.is_action_pressed("GrabPiece"):
 		# Check if the user has clicked on the piece's exact shape
 		var clicked_cell : int = _check_shape_clicked()
-		if clicked_cell != -1:
+		if clicked_cell != NO_CELL_CLICKED:
 			print("Piece shape clicked: " + name)
 			on_clicked(clicked_cell)
 
@@ -271,7 +272,7 @@ func _check_shape_clicked() -> int:
 		var cell11 : Vector2 = cell00 + Vector2(levelGridReference.tile_set.tile_size.x, levelGridReference.tile_set.tile_size.y)
 		if relative_click_position.x >= cell00.x and relative_click_position.x <= cell11.x and relative_click_position.y >= cell00.y and relative_click_position.y < cell11.y: # I really wish gdscript let you break statements across lines
 			return i # Mouse is inside one of the piece's cells
-	return -1
+	return NO_CELL_CLICKED
 	
 func _start_rotation_tween():
 	# Create the tween to animate the rotation

--- a/Birthday-2024-Project/Scripts/PieceLogic.gd
+++ b/Birthday-2024-Project/Scripts/PieceLogic.gd
@@ -77,7 +77,8 @@ func cancel_movement_tween():
 		_movement_tween.stop()
 	_movement_tween = null
 	
-func rotate_clockwise():
+func rotate_clockwise(center_cell : int):
+	var previous_cell_pos: Vector2 = get_cell_pos(center_cell)
 	# Update rotation variables
 	if current_rotation_state == RotationStates.DEG_270:
 		current_rotation_state = RotationStates.DEG_0
@@ -85,10 +86,15 @@ func rotate_clockwise():
 		current_rotation_state = current_rotation_state + 1 as RotationStates
 	
 	_current_angle_target += PI * 0.5
-	update_current_cells()	
+	update_current_cells()
+	var origin_cell_movement: Vector2 = _originOffset.rotated(_current_angle_target) - GetOriginCellOffset()
+	var center_cell_movement: Vector2 = (get_cell_pos(center_cell) + origin_cell_movement) - previous_cell_pos
+		
 	_start_rotation_tween()
+	movement_tween_to(global_position - center_cell_movement, ROTATION_ANIMATION_DURATION)
 	
-func rotate_anticlockwise():
+func rotate_anticlockwise(center_cell : int):
+	var previous_cell_pos: Vector2 = get_cell_pos(center_cell)
 	# Update rotation variables
 	if current_rotation_state == RotationStates.DEG_0:
 		current_rotation_state = RotationStates.DEG_270
@@ -96,8 +102,12 @@ func rotate_anticlockwise():
 		current_rotation_state = current_rotation_state - 1 as RotationStates
 	
 	_current_angle_target -= PI * 0.5
-	update_current_cells()	
+	update_current_cells()
+	var origin_cell_movement: Vector2 = _originOffset.rotated(_current_angle_target) - GetOriginCellOffset()
+	var center_cell_movement: Vector2 = (get_cell_pos(center_cell) + origin_cell_movement) - previous_cell_pos
+		
 	_start_rotation_tween()
+	movement_tween_to(global_position - center_cell_movement, ROTATION_ANIMATION_DURATION)
 	
 func cancel_rotation_tween():
 	if _rotation_tween != null:
@@ -202,13 +212,15 @@ func place_piece(grid_position: Vector2i, move_to: Vector2):
 		return
 	current_placement_state = PlacementStates.PLACED
 	movement_tween_to(move_to, PLACED_ANIMATION_DURATION)
-	
-func target_vector(target_pos: Vector2, target_cell_index: int) -> Vector2:
-	var target_cell : Vector2i = _current_cells[target_cell_index]
+
+func get_cell_pos(cell_index: int) -> Vector2:
+	var cell : Vector2i = _current_cells[cell_index]
 	var tile_size = levelGridReference.tile_set.tile_size
-	var cell_pos : Vector2 = GetOriginCellPosition() + Vector2(target_cell.x * tile_size.x, target_cell.y * tile_size.y)
+	return GetOriginCellPosition() + Vector2(cell.x * tile_size.x, cell.y * tile_size.y)
+
+func target_vector(target_pos: Vector2, target_cell_index: int) -> Vector2:
 	# Returns vector that moves the center of the targeted cell to the target position
-	return target_pos - cell_pos
+	return target_pos - get_cell_pos(target_cell_index)
 	
 ###############################################################################
 


### PR DESCRIPTION
# Description

Updated the code so that the pieces have better movement when held.
This is closer to what I saw of the real game, and I think it feels better.

## Related issue(s)

Not exactly related to an issue, although it should change #42. I'm not 100% happy with the rotation yet though,  it could be smoother.

## List of changes

- The mouse will always be grabbing the same cell of the piece, which will maintain even when rotating
- When over the grid, the piece will move to its placed position and not move until the mouse moves out of the same grid cell
<br/>

- GameManager.gd - Various changes in piece movement and settling
- GridLogic.gd - Added function that checks if a position is off grid, rather than a piece
- PieceLogic.gd - Changed _input() and related functions to send the clicked cell index to the game manager
