### PR TITLE
UI Adjustments after merge

### DIFF
--- a/Birthday-2024-Project/Art/OfficialPieceArt/Campaign_normal.png.import
+++ b/Birthday-2024-Project/Art/OfficialPieceArt/Campaign_normal.png.import
@@ -3,15 +3,15 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://xgmlqugfjb00"
-path="res://.godot/imported/Campaign_Normal.png-7eb3bb182fa84a80d4563ebaee4000ce.ctex"
+path="res://.godot/imported/Campaign_normal.png-10e91fc106ea14af2e2038d5ec59abab.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Art/OfficialPieceArt/Campaign_Normal.png"
-dest_files=["res://.godot/imported/Campaign_Normal.png-7eb3bb182fa84a80d4563ebaee4000ce.ctex"]
+source_file="res://Art/OfficialPieceArt/Campaign_normal.png"
+dest_files=["res://.godot/imported/Campaign_normal.png-10e91fc106ea14af2e2038d5ec59abab.ctex"]
 
 [params]
 

--- a/Birthday-2024-Project/Art/OfficialPieceArt/Campaign_pressed.png.import
+++ b/Birthday-2024-Project/Art/OfficialPieceArt/Campaign_pressed.png.import
@@ -3,15 +3,15 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://b1wnjeiltasgg"
-path="res://.godot/imported/Campaign_Pressed.png-d5fadd7f38e3a348c0e4a29b829bdd2a.ctex"
+path="res://.godot/imported/Campaign_pressed.png-d361cf0beedb8a39a230288b6e6e4b36.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Art/OfficialPieceArt/Campaign_Pressed.png"
-dest_files=["res://.godot/imported/Campaign_Pressed.png-d5fadd7f38e3a348c0e4a29b829bdd2a.ctex"]
+source_file="res://Art/OfficialPieceArt/Campaign_pressed.png"
+dest_files=["res://.godot/imported/Campaign_pressed.png-d361cf0beedb8a39a230288b6e6e4b36.ctex"]
 
 [params]
 

--- a/Birthday-2024-Project/Art/OfficialPieceArt/Level_type_normal.png.import
+++ b/Birthday-2024-Project/Art/OfficialPieceArt/Level_type_normal.png.import
@@ -3,15 +3,15 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://bgp7ytyux5ax4"
-path="res://.godot/imported/Level_type_Normal.png-5efa6b0acb3206d9cdf7bdfcdf0fe18a.ctex"
+path="res://.godot/imported/Level_type_normal.png-146f960ea1bb220d44212337c0e2db21.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Art/OfficialPieceArt/Level_type_Normal.png"
-dest_files=["res://.godot/imported/Level_type_Normal.png-5efa6b0acb3206d9cdf7bdfcdf0fe18a.ctex"]
+source_file="res://Art/OfficialPieceArt/Level_type_normal.png"
+dest_files=["res://.godot/imported/Level_type_normal.png-146f960ea1bb220d44212337c0e2db21.ctex"]
 
 [params]
 

--- a/Birthday-2024-Project/MainScenes/campaign_selection.tscn
+++ b/Birthday-2024-Project/MainScenes/campaign_selection.tscn
@@ -6,13 +6,13 @@
 [ext_resource type="Script" path="res://Scripts/UI/CampaignSelect/CampaignSelectStartScreen.gd" id="3_k52jr"]
 [ext_resource type="Texture2D" uid="uid://ll2r6k84b1vw" path="res://Art/UI/Background/Background_default_Light_textured_v2.png" id="5_5vjk0"]
 [ext_resource type="Theme" uid="uid://7jinxao27kiu" path="res://Art/UI/Themes/Settings_Button_theme.tres" id="6_anpq0"]
-[ext_resource type="Texture2D" uid="uid://xgmlqugfjb00" path="res://Art/OfficialPieceArt/Campaign_Normal.png" id="6_cc3ui"]
+[ext_resource type="Texture2D" uid="uid://xgmlqugfjb00" path="res://Art/OfficialPieceArt/Campaign_normal.png" id="6_cc3ui"]
 [ext_resource type="Texture2D" uid="uid://5fr6mp3yk6bj" path="res://Art/UI/UiReferencesAndMockups/CollectionSelectScreen.png" id="6_i1bcf"]
 [ext_resource type="Texture2D" uid="uid://b7jmya8c7al0t" path="res://Art/OfficialPieceArt/Campaign_Hover.png" id="7_eo82e"]
 [ext_resource type="Theme" uid="uid://clkf6xmmherj8" path="res://Art/UI/Themes/Exit_Button_theme.tres" id="7_oegh3"]
-[ext_resource type="Texture2D" uid="uid://b1wnjeiltasgg" path="res://Art/OfficialPieceArt/Campaign_Pressed.png" id="8_bdkyx"]
+[ext_resource type="Texture2D" uid="uid://b1wnjeiltasgg" path="res://Art/OfficialPieceArt/Campaign_pressed.png" id="8_bdkyx"]
 [ext_resource type="Theme" uid="uid://ddnhn5ud1sj7x" path="res://Art/UI/Themes/Back_Button_theme.tres" id="8_v563t"]
-[ext_resource type="Texture2D" uid="uid://bgp7ytyux5ax4" path="res://Art/OfficialPieceArt/Level_type_Normal.png" id="9_6n0xi"]
+[ext_resource type="Texture2D" uid="uid://bgp7ytyux5ax4" path="res://Art/OfficialPieceArt/Level_type_normal.png" id="9_6n0xi"]
 [ext_resource type="Texture2D" uid="uid://jpu45bfgsavl" path="res://Art/OfficialPieceArt/Level_type_Hover.png" id="10_ut252"]
 [ext_resource type="Texture2D" uid="uid://plb8jwpj3giv" path="res://Art/OfficialPieceArt/Level_type_Pressed.png" id="11_7q3fa"]
 
@@ -122,6 +122,24 @@ theme_override_styles/normal = SubResource("StyleBoxTexture_d0nye")
 theme_override_styles/hover = SubResource("StyleBoxTexture_8h43p")
 theme_override_styles/pressed = SubResource("StyleBoxTexture_wtv88")
 
+[node name="Campaign Label" type="Label" parent="CampaignSelectUiManager/CampaignSelectStartScreen/Panel/Campaign Levels"]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -142.5
+offset_top = -80.0
+offset_right = 142.5
+offset_bottom = -17.0
+grow_horizontal = 2
+grow_vertical = 0
+theme_override_font_sizes/font_size = 50
+text = "CAMPAIGN"
+horizontal_alignment = 1
+vertical_alignment = 1
+
 [node name="Sapling Levels" type="Button" parent="CampaignSelectUiManager/CampaignSelectStartScreen/Panel"]
 layout_mode = 1
 anchors_preset = 8
@@ -141,6 +159,24 @@ size_flags_horizontal = 3
 theme_override_styles/normal = SubResource("StyleBoxTexture_pbvc3")
 theme_override_styles/hover = SubResource("StyleBoxTexture_awk44")
 theme_override_styles/pressed = SubResource("StyleBoxTexture_p12qm")
+
+[node name="Saplings Label" type="Label" parent="CampaignSelectUiManager/CampaignSelectStartScreen/Panel/Sapling Levels"]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -233.0
+offset_top = -80.0
+offset_right = 233.0
+offset_bottom = -17.0
+grow_horizontal = 2
+grow_vertical = 0
+theme_override_font_sizes/font_size = 50
+text = "SAPLING LEVELS"
+horizontal_alignment = 1
+vertical_alignment = 1
 
 [node name="Settings Button" type="Button" parent="CampaignSelectUiManager/CampaignSelectStartScreen/Panel"]
 layout_mode = 1
@@ -175,25 +211,6 @@ offset_bottom = 128.0
 size_flags_horizontal = 4
 size_flags_vertical = 4
 theme = ExtResource("8_v563t")
-
-[node name="Campaign Label" type="Label" parent="CampaignSelectUiManager/CampaignSelectStartScreen/Panel"]
-layout_mode = 0
-offset_left = 437.0
-offset_top = 785.0
-offset_right = 722.0
-offset_bottom = 848.0
-rotation = -0.0349066
-theme_override_font_sizes/font_size = 50
-text = "CAMPAIGN"
-
-[node name="Saplings Label" type="Label" parent="CampaignSelectUiManager/CampaignSelectStartScreen/Panel"]
-offset_left = 1114.0
-offset_top = 779.0
-offset_right = 1580.0
-offset_bottom = 842.0
-rotation = 0.0226893
-theme_override_font_sizes/font_size = 50
-text = "SAPLING LEVELS"
 
 [node name="CollectionSelectScreenRef" type="Sprite2D" parent="."]
 visible = false

--- a/Birthday-2024-Project/MainScenes/sapling_level_select_5.tscn
+++ b/Birthday-2024-Project/MainScenes/sapling_level_select_5.tscn
@@ -20,7 +20,7 @@
 [ext_resource type="Resource" uid="uid://bdh0kf0y6d0df" path="res://Resources/SubmittedLevels/Tradgore.tres" id="18_03wlg"]
 [ext_resource type="Resource" uid="uid://cwwvdlqy245k1" path="res://Resources/SubmittedLevels/Turtyo.tres" id="19_1g2m0"]
 [ext_resource type="Resource" uid="uid://cmrspgq3v36k6" path="res://Resources/SubmittedLevels/WamWarcen.tres" id="20_c4lru"]
-[ext_resource type="Resource" uid="uid://cagvipu6hy0pq" path="res://Resources/SubmittedLevels/Wanderer.tres" id="21_uc760"]
+[ext_resource type="Resource" uid="uid://cagvipu6hy0pq" path="res://Resources/SubmittedLevels/wanderer.tres" id="21_uc760"]
 [ext_resource type="Resource" uid="uid://cjuv771fmaded" path="res://Resources/SubmittedLevels/Weeboss.tres" id="22_rttov"]
 [ext_resource type="Resource" uid="uid://dsdm3efm4p8fb" path="res://Resources/SubmittedLevels/Weirder.tres" id="23_4pbp8"]
 
@@ -42,7 +42,7 @@ pageNumber = 5
 lastPageNumber = 5
 
 [node name="Title" parent="LevelSelectMenu/Panel" index="0"]
-text = "COMMUNITY"
+text = "SAPLING LEVELS"
 
 [node name="Level Button" parent="LevelSelectMenu/Panel/Level Select Buttons" index="0"]
 levelData = ExtResource("4_mvxxg")

--- a/Birthday-2024-Project/ScenePrefabs/CreditsScreen.tscn
+++ b/Birthday-2024-Project/ScenePrefabs/CreditsScreen.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=9 format=3 uid="uid://cr52r13hg2vlu"]
+[gd_scene load_steps=8 format=3 uid="uid://cr52r13hg2vlu"]
 
 [ext_resource type="Script" path="res://Scripts/UI/MainMenu/CreditsScreen.gd" id="1_6as2f"]
 [ext_resource type="Theme" uid="uid://cp1430xlncsx2" path="res://Art/UI/Themes/Fauna_2024_birthday_game_theme.tres" id="1_a7ojj"]
-[ext_resource type="Texture2D" uid="uid://bjqluj600yhja" path="res://Art/Map_ResolutionClearance.png" id="2_5thx4"]
 [ext_resource type="Texture2D" uid="uid://ll2r6k84b1vw" path="res://Art/UI/Background/Background_default_Light_textured_v2.png" id="3_hr80e"]
 [ext_resource type="Theme" uid="uid://7jinxao27kiu" path="res://Art/UI/Themes/Settings_Button_theme.tres" id="4_nowih"]
 [ext_resource type="Theme" uid="uid://ddnhn5ud1sj7x" path="res://Art/UI/Themes/Back_Button_theme.tres" id="5_0lgxm"]
@@ -28,17 +27,6 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 pivot_offset = Vector2(960, 540)
-
-[node name="TextureRect" type="TextureRect" parent="Control"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-texture = ExtResource("2_5thx4")
-expand_mode = 3
-stretch_mode = 5
 
 [node name="TextureRect2" type="NinePatchRect" parent="Control"]
 layout_mode = 1
@@ -96,6 +84,18 @@ offset_bottom = 120.0
 grow_horizontal = 0
 theme = ExtResource("6_qycl5")
 
+[node name="Title" type="Label" parent="Panel"]
+layout_mode = 1
+anchors_preset = 10
+anchor_right = 1.0
+offset_top = 85.0
+offset_bottom = 210.0
+grow_horizontal = 2
+size_flags_horizontal = 4
+theme_override_font_sizes/font_size = 100
+text = "CREDITS"
+horizontal_alignment = 1
+
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
 custom_minimum_size = Vector2(100, 100)
 layout_mode = 1
@@ -105,9 +105,9 @@ anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
 offset_left = -550.0
-offset_top = -400.0
+offset_top = -290.0
 offset_right = 550.0
-offset_bottom = 400.0
+offset_bottom = 460.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_constants/separation = 0
@@ -117,29 +117,27 @@ alignment = 1
 custom_minimum_size = Vector2(100, 100)
 layout_mode = 2
 size_flags_horizontal = 3
-theme_override_constants/separation = 40
+size_flags_vertical = 0
+theme_override_constants/separation = 30
 alignment = 1
 
 [node name="Lead" type="RichTextLabel" parent="HBoxContainer/LeftColumn"]
 layout_mode = 2
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 1
-theme_override_font_sizes/normal_font_size = 25
+theme_override_font_sizes/normal_font_size = 30
 bbcode_enabled = true
 text = "[center][font_size=50]Lead[/font_size]
-[font_size=30]Casulono[/font_size]
+Casulono
 [/center]"
 fit_content = true
 scroll_active = false
 
 [node name="Game Idea" type="RichTextLabel" parent="HBoxContainer/LeftColumn"]
 layout_mode = 2
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 1
 theme_override_font_sizes/normal_font_size = 30
 bbcode_enabled = true
-text = "[center][font_size=50]Game Idea[/font_size]
-[font_size=30]Mikotey[/font_size]
+text = "[center][font_size=5
+0]Project Idea[/font_size]
+Mikotey
 [/center]"
 fit_content = true
 scroll_active = false
@@ -147,18 +145,17 @@ scroll_active = false
 [node name="Developers" type="RichTextLabel" parent="HBoxContainer/LeftColumn"]
 clip_contents = false
 layout_mode = 2
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 1
-theme_override_font_sizes/normal_font_size = 25
+theme_override_constants/outline_size = 0
+theme_override_font_sizes/normal_font_size = 30
 bbcode_enabled = true
 text = "[center][font_size=50]Developers[/font_size]
-[font_size=30]Bishop[/font_size]
-[font_size=30]Casulono[/font_size]
-[font_size=30]Duarpeto[/font_size]
-[font_size=30]Diego A.[/font_size]
-[font_size=30]Mikotey[/font_size]
-[font_size=30]Sambino[/font_size]
-[font_size=30]Vorthein[/font_size]
+Bishop
+Casulono
+Duarpeto
+Diego A.
+Mikotey
+Sambino
+Vorthein
 [/center]"
 fit_content = true
 scroll_active = false
@@ -168,51 +165,28 @@ custom_minimum_size = Vector2(100, 100)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 0
+theme_override_constants/separation = 30
 alignment = 1
-
-[node name="Credits" type="RichTextLabel" parent="HBoxContainer/CenterColumn"]
-layout_mode = 2
-size_flags_vertical = 2
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 1
-theme_override_font_sizes/normal_font_size = 40
-bbcode_enabled = true
-text = "[center]Credits[/center]"
-fit_content = true
-scroll_active = false
-
-[node name="Margin" type="RichTextLabel" parent="HBoxContainer/CenterColumn"]
-layout_mode = 2
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 1
-theme_override_font_sizes/normal_font_size = 25
-bbcode_enabled = true
-text = "
-
-"
-fit_content = true
-scroll_active = false
 
 [node name="Art" type="RichTextLabel" parent="HBoxContainer/CenterColumn"]
 layout_mode = 2
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 1
-theme_override_font_sizes/normal_font_size = 25
+theme_override_font_sizes/normal_font_size = 30
 bbcode_enabled = true
-text = "[center][font_size=50]Art[/font_size]
-[center][font_size=40]Pieces Assets[/font_size]
-[font_size=30]crashairsprig[/font_size]
-[font_size=30]Cyanophycée[/font_size]
-[font_size=30]EndyStarBoy[/font_size]
-[font_size=30]HDAK art[/font_size]
-[font_size=30]Lunar[/font_size]
-[font_size=30]mpmrpjb[/font_size]
+text = "[center][font_size=60]Art[/font_size]
 
-[font_size=40]UI Assets[/font_size]
-[font_size=30]HDAK art[/font_size]
+[center][font_size=50]Pieces[/font_size]
+crashairsprig
+Cyanophycée
+EndyStarBoy
+HDAK art
+Lunar
+mpmrpjb
 
-[font_size=40]Animations[/font_size]
-[font_size=30]Mikotey[/font_size]"
+[font_size=50]UI[/font_size]
+HDAK art
+
+[font_size=50]Animations[/font_size]
+Mikotey"
 fit_content = true
 scroll_active = false
 
@@ -220,64 +194,43 @@ scroll_active = false
 custom_minimum_size = Vector2(100, 100)
 layout_mode = 2
 size_flags_horizontal = 3
-theme_override_constants/separation = 40
+size_flags_vertical = 0
+theme_override_constants/separation = 30
 alignment = 1
-
-[node name="Testing" type="RichTextLabel" parent="HBoxContainer/RightColumn"]
-visible = false
-clip_contents = false
-layout_mode = 2
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 1
-theme_override_font_sizes/normal_font_size = 30
-bbcode_enabled = true
-text = "[center][font_size=50]Game Testing[/font_size]
-[font_size=30]Tester Name1[/font_size]
-[font_size=30]Tester Name2[/font_size]
-[font_size=30]Tester Name3[/font_size]
-[/center]"
-fit_content = true
-scroll_active = false
 
 [node name="Music" type="RichTextLabel" parent="HBoxContainer/RightColumn"]
 layout_mode = 2
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 1
 theme_override_font_sizes/normal_font_size = 30
 bbcode_enabled = true
-text = "[center][font_size=50]Audio[/font_size]
-[font_size=40]Music[/font_size]
-[font_size=30]DarkEcoFreak[/font_size]
-[font_size=40]SFX[/font_size]
-[font_size=30]Casulono[/font_size]
+text = "[center][font_size=50]Music[/font_size]
+DarkEcoFreak
+
+[font_size=50]SFX[/font_size]
+Casulono
 [/center]"
 fit_content = true
 scroll_active = false
 
 [node name="Level Design" type="RichTextLabel" parent="HBoxContainer/RightColumn"]
 layout_mode = 2
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 1
 theme_override_font_sizes/normal_font_size = 30
 bbcode_enabled = true
-text = "[center][font_size=50]Level Design[/font_size]
-[font_size=30]DarkEcoFreak[/font_size]
-[font_size=30]HDAK art[/font_size]
-[font_size=30]RaddLad[/font_size]
-[font_size=30]Vorthein[/font_size]
+text = "[center][font_size=50]Campaign[/font_size]
+DarkEcoFreak
+HDAK art
+RaddLad
+Vorthein
 [/center]"
 fit_content = true
 scroll_active = false
 
 [node name="General Help" type="RichTextLabel" parent="HBoxContainer/RightColumn"]
 layout_mode = 2
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 1
 theme_override_font_sizes/normal_font_size = 30
 bbcode_enabled = true
-text = "[center][font_size=50]General Help[/font_size]
-[font_size=30]DarkEcoFreak[/font_size]
-[font_size=30]RaddLad[/font_size]
+text = "[center][font_size=50]Submissions[/font_size]
+DarkEcoFreak
+RaddLad
 [/center]"
 fit_content = true
 scroll_active = false

--- a/Birthday-2024-Project/ScenePrefabs/MainMenuUiManager.tscn
+++ b/Birthday-2024-Project/ScenePrefabs/MainMenuUiManager.tscn
@@ -646,7 +646,7 @@ text = "Play"
 
 [node name="Messages Button" type="Button" parent="StartScreen/Panel/Navigation Buttons"]
 layout_mode = 2
-text = "Sapling's Messages"
+text = "Sapling Messages"
 
 [node name="Gallery Button" type="Button" parent="StartScreen/Panel/Navigation Buttons"]
 layout_mode = 2


### PR DESCRIPTION
# Description

Adjustments after merging the Community assets update and Credits screen PRs.
Made a number of adjustments based on preference that can be reversed depending on opinions and feedback

## List of changes

- some missing import files
- anchoring Campaign Select text label to handle resolution changes
- Sapling Level Select page 5 label updated to "Sapling Levels" like other pages
- Main Menu messages button text changed to "Sapling Messages" similar to "Sapling Levels"
- Preferred adjustments to Credits:
1. Removed outline on texts
2. Standardized name texts to 30
3. Removed extra font size tags that were the same as the theme override
4. Added title text bar similar to other screens
5. Standardized headers and subheaders to 50 size
6. Added spacing between headers
7. Changed Art super header to 60 size
8. Aligned columns on top edge
9. Removed Audio super header so columns would have closer lengths
10. Changed "Game Idea" to "Project Idea" since the game concept hasn't diverged from the original
11. Removed "Assets" from art headers
12. Changed "Level Designs" to "Campaign"
13. Changed "General Help" to "Submissions". I think it's good to be more specific