### PR TITLE
Skip button update

### DIFF
--- a/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel1.tres
+++ b/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel1.tres
@@ -1,6 +1,8 @@
-[gd_resource type="Resource" script_class="LevelSetup" load_steps=3 format=3 uid="uid://b2tco3xr6sxna"]
+[gd_resource type="Resource" script_class="LevelSetup" load_steps=5 format=3 uid="uid://b2tco3xr6sxna"]
 
 [ext_resource type="Script" path="res://Scripts/LevelSetup.gd" id="1_14d3v"]
+[ext_resource type="Texture2D" uid="uid://cx4qtp5plvyyy" path="res://Art/Emotes/comfy.png" id="1_kn4ei"]
+[ext_resource type="Texture2D" uid="uid://4gj42xmp2266" path="res://Art/Emotes/angry.png" id="2_4oh1c"]
 [ext_resource type="Resource" uid="uid://tyyw6kpycqnv" path="res://Resources/TutorialData/TutorialLevel1.tres" id="2_21u84"]
 
 [resource]
@@ -10,4 +12,6 @@ jsonData = "[\"{\\\"PIECE_SETUP_GRID_POSITION_X_KEY\\\":0,\\\"PIECE_SETUP_GRID_P
 author = ""
 message = ""
 levelName = ""
+levelPreview = ExtResource("2_4oh1c")
+levelComplete = ExtResource("1_kn4ei")
 tutorialData = ExtResource("2_21u84")

--- a/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel10.tres
+++ b/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel10.tres
@@ -1,6 +1,8 @@
-[gd_resource type="Resource" script_class="LevelSetup" load_steps=3 format=3 uid="uid://cmb6gl3lx6o7l"]
+[gd_resource type="Resource" script_class="LevelSetup" load_steps=5 format=3 uid="uid://cmb6gl3lx6o7l"]
 
+[ext_resource type="Texture2D" uid="uid://cx4qtp5plvyyy" path="res://Art/Emotes/comfy.png" id="1_1impj"]
 [ext_resource type="Script" path="res://Scripts/LevelSetup.gd" id="1_cqugl"]
+[ext_resource type="Texture2D" uid="uid://4gj42xmp2266" path="res://Art/Emotes/angry.png" id="2_shw8c"]
 [ext_resource type="Resource" uid="uid://c3x2ku2v3ophq" path="res://Resources/TutorialData/TutorialLevel10.tres" id="2_yehck"]
 
 [resource]
@@ -10,4 +12,6 @@ jsonData = "[\"{\\\"PIECE_SETUP_GRID_POSITION_X_KEY\\\":0,\\\"PIECE_SETUP_GRID_P
 author = ""
 message = ""
 levelName = ""
+levelPreview = ExtResource("2_shw8c")
+levelComplete = ExtResource("1_1impj")
 tutorialData = ExtResource("2_yehck")

--- a/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel11.tres
+++ b/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel11.tres
@@ -1,6 +1,8 @@
-[gd_resource type="Resource" script_class="LevelSetup" load_steps=3 format=3 uid="uid://o87hew4q6f02"]
+[gd_resource type="Resource" script_class="LevelSetup" load_steps=5 format=3 uid="uid://o87hew4q6f02"]
 
+[ext_resource type="Texture2D" uid="uid://cx4qtp5plvyyy" path="res://Art/Emotes/comfy.png" id="1_2hpei"]
 [ext_resource type="Script" path="res://Scripts/LevelSetup.gd" id="1_muuev"]
+[ext_resource type="Texture2D" uid="uid://4gj42xmp2266" path="res://Art/Emotes/angry.png" id="2_5tino"]
 [ext_resource type="Resource" uid="uid://cj4yxr8i8wmno" path="res://Resources/TutorialData/TutorialLevel11.tres" id="2_dxpi6"]
 
 [resource]
@@ -10,4 +12,6 @@ jsonData = "[\"{\\\"PIECE_SETUP_GRID_POSITION_X_KEY\\\":-2,\\\"PIECE_SETUP_GRID_
 author = ""
 message = ""
 levelName = ""
+levelPreview = ExtResource("2_5tino")
+levelComplete = ExtResource("1_2hpei")
 tutorialData = ExtResource("2_dxpi6")

--- a/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel12.tres
+++ b/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel12.tres
@@ -1,7 +1,9 @@
-[gd_resource type="Resource" script_class="LevelSetup" load_steps=3 format=3 uid="uid://bmtyubrxcnchx"]
+[gd_resource type="Resource" script_class="LevelSetup" load_steps=5 format=3 uid="uid://bmtyubrxcnchx"]
 
+[ext_resource type="Texture2D" uid="uid://cx4qtp5plvyyy" path="res://Art/Emotes/comfy.png" id="1_38ksu"]
 [ext_resource type="Script" path="res://Scripts/LevelSetup.gd" id="1_nbyfg"]
 [ext_resource type="Resource" uid="uid://md0pw4vgcr7a" path="res://Resources/TutorialData/TutorialLevel12.tres" id="2_2o6kn"]
+[ext_resource type="Texture2D" uid="uid://4gj42xmp2266" path="res://Art/Emotes/angry.png" id="2_he78v"]
 
 [resource]
 script = ExtResource("1_nbyfg")
@@ -10,4 +12,6 @@ jsonData = "[\"{\\\"PIECE_SETUP_GRID_POSITION_X_KEY\\\":-4,\\\"PIECE_SETUP_GRID_
 author = ""
 message = ""
 levelName = ""
+levelPreview = ExtResource("2_he78v")
+levelComplete = ExtResource("1_38ksu")
 tutorialData = ExtResource("2_2o6kn")

--- a/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel13.tres
+++ b/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel13.tres
@@ -1,7 +1,9 @@
-[gd_resource type="Resource" script_class="LevelSetup" load_steps=3 format=3 uid="uid://bpvm078rj0xrc"]
+[gd_resource type="Resource" script_class="LevelSetup" load_steps=5 format=3 uid="uid://bpvm078rj0xrc"]
 
+[ext_resource type="Texture2D" uid="uid://cx4qtp5plvyyy" path="res://Art/Emotes/comfy.png" id="1_0nyef"]
 [ext_resource type="Script" path="res://Scripts/LevelSetup.gd" id="1_sjwdw"]
 [ext_resource type="Resource" uid="uid://gq5qcjqaj74" path="res://Resources/TutorialData/TutorialLevel13.tres" id="2_fp5ip"]
+[ext_resource type="Texture2D" uid="uid://4gj42xmp2266" path="res://Art/Emotes/angry.png" id="2_kxjqr"]
 
 [resource]
 script = ExtResource("1_sjwdw")
@@ -10,4 +12,6 @@ jsonData = "[\"{\\\"PIECE_SETUP_GRID_POSITION_X_KEY\\\":-3,\\\"PIECE_SETUP_GRID_
 author = ""
 message = ""
 levelName = ""
+levelPreview = ExtResource("2_kxjqr")
+levelComplete = ExtResource("1_0nyef")
 tutorialData = ExtResource("2_fp5ip")

--- a/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel14.tres
+++ b/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel14.tres
@@ -1,6 +1,8 @@
-[gd_resource type="Resource" script_class="LevelSetup" load_steps=2 format=3 uid="uid://cwvfgeg8fqqj1"]
+[gd_resource type="Resource" script_class="LevelSetup" load_steps=4 format=3 uid="uid://cwvfgeg8fqqj1"]
 
 [ext_resource type="Script" path="res://Scripts/LevelSetup.gd" id="1_o0gnp"]
+[ext_resource type="Texture2D" uid="uid://cx4qtp5plvyyy" path="res://Art/Emotes/comfy.png" id="1_yvldj"]
+[ext_resource type="Texture2D" uid="uid://4gj42xmp2266" path="res://Art/Emotes/angry.png" id="2_npxvk"]
 
 [resource]
 script = ExtResource("1_o0gnp")
@@ -9,3 +11,5 @@ jsonData = "[\"{\\\"PIECE_SETUP_GRID_POSITION_X_KEY\\\":-3,\\\"PIECE_SETUP_GRID_
 author = ""
 message = ""
 levelName = ""
+levelPreview = ExtResource("2_npxvk")
+levelComplete = ExtResource("1_yvldj")

--- a/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel15.tres
+++ b/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel15.tres
@@ -1,6 +1,8 @@
-[gd_resource type="Resource" script_class="LevelSetup" load_steps=2 format=3 uid="uid://e5r8ufelwltl"]
+[gd_resource type="Resource" script_class="LevelSetup" load_steps=4 format=3 uid="uid://e5r8ufelwltl"]
 
+[ext_resource type="Texture2D" uid="uid://cx4qtp5plvyyy" path="res://Art/Emotes/comfy.png" id="1_k15en"]
 [ext_resource type="Script" path="res://Scripts/LevelSetup.gd" id="1_uly65"]
+[ext_resource type="Texture2D" uid="uid://4gj42xmp2266" path="res://Art/Emotes/angry.png" id="2_pvxep"]
 
 [resource]
 script = ExtResource("1_uly65")
@@ -9,3 +11,5 @@ jsonData = "[\"{\\\"PIECE_SETUP_GRID_POSITION_X_KEY\\\":-2,\\\"PIECE_SETUP_GRID_
 author = ""
 message = ""
 levelName = ""
+levelPreview = ExtResource("2_pvxep")
+levelComplete = ExtResource("1_k15en")

--- a/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel16.tres
+++ b/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel16.tres
@@ -1,6 +1,8 @@
-[gd_resource type="Resource" script_class="LevelSetup" load_steps=2 format=3 uid="uid://ctdxdhw8e2m53"]
+[gd_resource type="Resource" script_class="LevelSetup" load_steps=4 format=3 uid="uid://ctdxdhw8e2m53"]
 
+[ext_resource type="Texture2D" uid="uid://cx4qtp5plvyyy" path="res://Art/Emotes/comfy.png" id="1_ebfvy"]
 [ext_resource type="Script" path="res://Scripts/LevelSetup.gd" id="1_rqqg4"]
+[ext_resource type="Texture2D" uid="uid://4gj42xmp2266" path="res://Art/Emotes/angry.png" id="2_51ddn"]
 
 [resource]
 script = ExtResource("1_rqqg4")
@@ -9,3 +11,5 @@ jsonData = "[\"{\\\"PIECE_SETUP_GRID_POSITION_X_KEY\\\":-4,\\\"PIECE_SETUP_GRID_
 author = ""
 message = ""
 levelName = ""
+levelPreview = ExtResource("2_51ddn")
+levelComplete = ExtResource("1_ebfvy")

--- a/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel17.tres
+++ b/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel17.tres
@@ -1,6 +1,8 @@
-[gd_resource type="Resource" script_class="LevelSetup" load_steps=2 format=3 uid="uid://c65qvmq3kx7ak"]
+[gd_resource type="Resource" script_class="LevelSetup" load_steps=4 format=3 uid="uid://c65qvmq3kx7ak"]
 
 [ext_resource type="Script" path="res://Scripts/LevelSetup.gd" id="1_7ajel"]
+[ext_resource type="Texture2D" uid="uid://cx4qtp5plvyyy" path="res://Art/Emotes/comfy.png" id="1_ol7gx"]
+[ext_resource type="Texture2D" uid="uid://4gj42xmp2266" path="res://Art/Emotes/angry.png" id="2_kxpp4"]
 
 [resource]
 script = ExtResource("1_7ajel")
@@ -9,3 +11,5 @@ jsonData = "[\"{\\\"PIECE_SETUP_GRID_POSITION_X_KEY\\\":-2,\\\"PIECE_SETUP_GRID_
 author = ""
 message = ""
 levelName = ""
+levelPreview = ExtResource("2_kxpp4")
+levelComplete = ExtResource("1_ol7gx")

--- a/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel2.tres
+++ b/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel2.tres
@@ -1,6 +1,8 @@
-[gd_resource type="Resource" script_class="LevelSetup" load_steps=3 format=3 uid="uid://ditmohdfb7nsp"]
+[gd_resource type="Resource" script_class="LevelSetup" load_steps=5 format=3 uid="uid://ditmohdfb7nsp"]
 
+[ext_resource type="Texture2D" uid="uid://cx4qtp5plvyyy" path="res://Art/Emotes/comfy.png" id="1_3fhcl"]
 [ext_resource type="Script" path="res://Scripts/LevelSetup.gd" id="1_et6ne"]
+[ext_resource type="Texture2D" uid="uid://4gj42xmp2266" path="res://Art/Emotes/angry.png" id="2_o8vcg"]
 [ext_resource type="Resource" uid="uid://du4kubo5a1y3a" path="res://Resources/TutorialData/TutorialLevel2.tres" id="2_qye1i"]
 
 [resource]
@@ -10,4 +12,6 @@ jsonData = "[\"{\\\"PIECE_SETUP_GRID_POSITION_X_KEY\\\":-1,\\\"PIECE_SETUP_GRID_
 author = ""
 message = ""
 levelName = ""
+levelPreview = ExtResource("2_o8vcg")
+levelComplete = ExtResource("1_3fhcl")
 tutorialData = ExtResource("2_qye1i")

--- a/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel3.tres
+++ b/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel3.tres
@@ -1,7 +1,9 @@
-[gd_resource type="Resource" script_class="LevelSetup" load_steps=3 format=3 uid="uid://dfno2p43e4g1d"]
+[gd_resource type="Resource" script_class="LevelSetup" load_steps=5 format=3 uid="uid://dfno2p43e4g1d"]
 
 [ext_resource type="Script" path="res://Scripts/LevelSetup.gd" id="1_4h1v6"]
+[ext_resource type="Texture2D" uid="uid://cx4qtp5plvyyy" path="res://Art/Emotes/comfy.png" id="1_prkfl"]
 [ext_resource type="Resource" uid="uid://i8n7uxrbu6pm" path="res://Resources/TutorialData/TutorialLevel3.tres" id="2_naxo5"]
+[ext_resource type="Texture2D" uid="uid://4gj42xmp2266" path="res://Art/Emotes/angry.png" id="2_oqive"]
 
 [resource]
 script = ExtResource("1_4h1v6")
@@ -10,4 +12,6 @@ jsonData = "[\"{\\\"PIECE_SETUP_GRID_POSITION_X_KEY\\\":1,\\\"PIECE_SETUP_GRID_P
 author = ""
 message = ""
 levelName = ""
+levelPreview = ExtResource("2_oqive")
+levelComplete = ExtResource("1_prkfl")
 tutorialData = ExtResource("2_naxo5")

--- a/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel4.tres
+++ b/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel4.tres
@@ -1,7 +1,9 @@
-[gd_resource type="Resource" script_class="LevelSetup" load_steps=3 format=3 uid="uid://c3y3p1hvhn2o2"]
+[gd_resource type="Resource" script_class="LevelSetup" load_steps=5 format=3 uid="uid://c3y3p1hvhn2o2"]
 
+[ext_resource type="Texture2D" uid="uid://cx4qtp5plvyyy" path="res://Art/Emotes/comfy.png" id="1_4olxt"]
 [ext_resource type="Script" path="res://Scripts/LevelSetup.gd" id="1_tpmh4"]
 [ext_resource type="Resource" uid="uid://bh448bg2xrnxl" path="res://Resources/TutorialData/TutorialLevel4.tres" id="2_6qkkq"]
+[ext_resource type="Texture2D" uid="uid://4gj42xmp2266" path="res://Art/Emotes/angry.png" id="2_c0rhf"]
 
 [resource]
 script = ExtResource("1_tpmh4")
@@ -10,4 +12,6 @@ jsonData = "[\"{\\\"PIECE_SETUP_GRID_POSITION_X_KEY\\\":0,\\\"PIECE_SETUP_GRID_P
 author = ""
 message = ""
 levelName = ""
+levelPreview = ExtResource("2_c0rhf")
+levelComplete = ExtResource("1_4olxt")
 tutorialData = ExtResource("2_6qkkq")

--- a/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel5.tres
+++ b/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel5.tres
@@ -1,7 +1,9 @@
-[gd_resource type="Resource" script_class="LevelSetup" load_steps=3 format=3 uid="uid://bvuh7hb4x6yqg"]
+[gd_resource type="Resource" script_class="LevelSetup" load_steps=5 format=3 uid="uid://bvuh7hb4x6yqg"]
 
+[ext_resource type="Texture2D" uid="uid://cx4qtp5plvyyy" path="res://Art/Emotes/comfy.png" id="1_em5mo"]
 [ext_resource type="Script" path="res://Scripts/LevelSetup.gd" id="1_p038p"]
 [ext_resource type="Resource" uid="uid://b06n0hwteyyyv" path="res://Resources/TutorialData/TutorialLevel5.tres" id="2_4t3qf"]
+[ext_resource type="Texture2D" uid="uid://4gj42xmp2266" path="res://Art/Emotes/angry.png" id="2_6icij"]
 
 [resource]
 script = ExtResource("1_p038p")
@@ -10,4 +12,6 @@ jsonData = "[\"{\\\"PIECE_SETUP_GRID_POSITION_X_KEY\\\":-2,\\\"PIECE_SETUP_GRID_
 author = ""
 message = ""
 levelName = ""
+levelPreview = ExtResource("2_6icij")
+levelComplete = ExtResource("1_em5mo")
 tutorialData = ExtResource("2_4t3qf")

--- a/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel6.tres
+++ b/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel6.tres
@@ -1,7 +1,9 @@
-[gd_resource type="Resource" script_class="LevelSetup" load_steps=3 format=3 uid="uid://56uryq40nvj3"]
+[gd_resource type="Resource" script_class="LevelSetup" load_steps=5 format=3 uid="uid://56uryq40nvj3"]
 
+[ext_resource type="Texture2D" uid="uid://cx4qtp5plvyyy" path="res://Art/Emotes/comfy.png" id="1_8cfv8"]
 [ext_resource type="Script" path="res://Scripts/LevelSetup.gd" id="1_kkscd"]
 [ext_resource type="Resource" uid="uid://btc703qoc3i5m" path="res://Resources/TutorialData/TutorialLevel6.tres" id="2_20rdr"]
+[ext_resource type="Texture2D" uid="uid://4gj42xmp2266" path="res://Art/Emotes/angry.png" id="2_obxeh"]
 
 [resource]
 script = ExtResource("1_kkscd")
@@ -10,4 +12,6 @@ jsonData = "[\"{\\\"PIECE_SETUP_GRID_POSITION_X_KEY\\\":1,\\\"PIECE_SETUP_GRID_P
 author = ""
 message = ""
 levelName = ""
+levelPreview = ExtResource("2_obxeh")
+levelComplete = ExtResource("1_8cfv8")
 tutorialData = ExtResource("2_20rdr")

--- a/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel7.tres
+++ b/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel7.tres
@@ -1,7 +1,9 @@
-[gd_resource type="Resource" script_class="LevelSetup" load_steps=3 format=3 uid="uid://rvydn0ua2ywc"]
+[gd_resource type="Resource" script_class="LevelSetup" load_steps=5 format=3 uid="uid://rvydn0ua2ywc"]
 
+[ext_resource type="Texture2D" uid="uid://cx4qtp5plvyyy" path="res://Art/Emotes/comfy.png" id="1_mq2k1"]
 [ext_resource type="Script" path="res://Scripts/LevelSetup.gd" id="1_si1xd"]
 [ext_resource type="Resource" uid="uid://mxju84yqye6p" path="res://Resources/TutorialData/TutorialLevel7.tres" id="2_7cvod"]
+[ext_resource type="Texture2D" uid="uid://4gj42xmp2266" path="res://Art/Emotes/angry.png" id="2_h4yel"]
 
 [resource]
 script = ExtResource("1_si1xd")
@@ -10,4 +12,6 @@ jsonData = "[\"{\\\"PIECE_SETUP_GRID_POSITION_X_KEY\\\":-4,\\\"PIECE_SETUP_GRID_
 author = ""
 message = ""
 levelName = ""
+levelPreview = ExtResource("2_h4yel")
+levelComplete = ExtResource("1_mq2k1")
 tutorialData = ExtResource("2_7cvod")

--- a/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel8.tres
+++ b/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel8.tres
@@ -1,7 +1,9 @@
-[gd_resource type="Resource" script_class="LevelSetup" load_steps=3 format=3 uid="uid://cvlm5htl0jgkf"]
+[gd_resource type="Resource" script_class="LevelSetup" load_steps=5 format=3 uid="uid://cvlm5htl0jgkf"]
 
 [ext_resource type="Script" path="res://Scripts/LevelSetup.gd" id="1_gxnpt"]
+[ext_resource type="Texture2D" uid="uid://cx4qtp5plvyyy" path="res://Art/Emotes/comfy.png" id="1_wp1th"]
 [ext_resource type="Resource" uid="uid://dp6i2782nx6bj" path="res://Resources/TutorialData/TutorialLevel8.tres" id="2_1isu8"]
+[ext_resource type="Texture2D" uid="uid://4gj42xmp2266" path="res://Art/Emotes/angry.png" id="2_xxqx5"]
 
 [resource]
 script = ExtResource("1_gxnpt")
@@ -10,4 +12,6 @@ jsonData = "[\"{\\\"PIECE_SETUP_GRID_POSITION_X_KEY\\\":2,\\\"PIECE_SETUP_GRID_P
 author = ""
 message = ""
 levelName = ""
+levelPreview = ExtResource("2_xxqx5")
+levelComplete = ExtResource("1_wp1th")
 tutorialData = ExtResource("2_1isu8")

--- a/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel9.tres
+++ b/Birthday-2024-Project/Resources/CampaignLevels/CampaignLevel9.tres
@@ -1,6 +1,8 @@
-[gd_resource type="Resource" script_class="LevelSetup" load_steps=3 format=3 uid="uid://cy2xbgm14khx2"]
+[gd_resource type="Resource" script_class="LevelSetup" load_steps=5 format=3 uid="uid://cy2xbgm14khx2"]
 
+[ext_resource type="Texture2D" uid="uid://cx4qtp5plvyyy" path="res://Art/Emotes/comfy.png" id="1_ibi53"]
 [ext_resource type="Script" path="res://Scripts/LevelSetup.gd" id="1_njosf"]
+[ext_resource type="Texture2D" uid="uid://4gj42xmp2266" path="res://Art/Emotes/angry.png" id="2_jdhuu"]
 [ext_resource type="Resource" uid="uid://b3mw1gm5844vq" path="res://Resources/TutorialData/TutorialLevel9.tres" id="2_u1be0"]
 
 [resource]
@@ -10,4 +12,6 @@ jsonData = "[\"{\\\"PIECE_SETUP_GRID_POSITION_X_KEY\\\":4,\\\"PIECE_SETUP_GRID_P
 author = ""
 message = ""
 levelName = ""
+levelPreview = ExtResource("2_jdhuu")
+levelComplete = ExtResource("1_ibi53")
 tutorialData = ExtResource("2_u1be0")

--- a/Birthday-2024-Project/Scripts/Game/States/GameWinState.gd
+++ b/Birthday-2024-Project/Scripts/Game/States/GameWinState.gd
@@ -16,11 +16,10 @@ func _reset_puzzle():
 func enter_state():
 	print("Entering Game Win State")
 	manager._can_interact = false
+	manager._gm.progression_tracker.MarkLevelCompleted(manager._levelData.resource_path)
 	if manager.myScreen.transitionData[LevelsSelectMenu.IS_CAMPAIGN_KEY]:
 		var thisLevelIndex : int = manager.myScreen.transitionData[LevelsSelectMenu.PASS_LEVEL_INDEX_KEY]
 		manager._gm.progression_tracker.SetLatestCampaignLevelCompleted(thisLevelIndex)
-	else:
-		manager._gm.progression_tracker.MarkLevelCompleted(manager._levelData.levelName)
 
 
 func exit_state():

--- a/Birthday-2024-Project/Scripts/GameManager.gd
+++ b/Birthday-2024-Project/Scripts/GameManager.gd
@@ -60,14 +60,12 @@ func go_to_next_level():
 		#last level
 		if thisLevelIndex + 1 >= _gm.campaign_level_library.Levels.size():
 			go_to_level_select()
-		#next level is unlocked
-		elif _gm.progression_tracker.GetLastCampaignLevelCompleted() + 1 > thisLevelIndex:
+		#go to next level if present, it will go to it no matter if it's unlocked but won't mark it as complete
+		else:
 			transitionData[LevelsSelectMenu.IS_CAMPAIGN_KEY] = true
 			transitionData[LevelsSelectMenu.PASS_LEVEL_DATA_KEY] = _gm.campaign_level_library.Levels[thisLevelIndex + 1]
+			_gm.progression_tracker.SetLatestCampaignLevelCompleted(thisLevelIndex)
 			myScreen.GoToScreen(load("res://MainScenes/main_level.tscn"), transitionData, ScreenManager.TransitionStyle.TURN_PAGE)
-		else:
-			#you haven't unlocked the next level, so go back to level select
-			go_to_level_select()
 	else:
 		#last level
 		if thisLevelIndex + 1 >= _gm.submitted_level_library.Levels.size():

--- a/Birthday-2024-Project/Scripts/UI/CampaignSelect/LevelsSelectMenu.gd
+++ b/Birthday-2024-Project/Scripts/UI/CampaignSelect/LevelsSelectMenu.gd
@@ -66,18 +66,13 @@ func _ready():
 		if levelLibrary.Levels.size() > levelIndex:
 			var levelData = levelLibrary.Levels[levelIndex]
 			button.levelData = levelData
-			if isCampaign:
-				if levelIndex > _gm.progression_tracker.GetLastCampaignLevelCompleted() + 1:
-					button.SetupButtonMode(LevelButton.LevelButtonMode.LOCKED, levelIndex)
-				elif levelIndex == _gm.progression_tracker.GetLastCampaignLevelCompleted() + 1:
-					button.SetupButtonMode(LevelButton.LevelButtonMode.INCOMPLETE, levelIndex)
-				else:
-					button.SetupButtonMode(LevelButton.LevelButtonMode.COMPLETE, levelIndex)
+			
+			if isCampaign and levelIndex > _gm.progression_tracker.GetLastCampaignLevelCompleted() + 1:
+				button.SetupButtonMode(LevelButton.LevelButtonMode.LOCKED, levelIndex)
+			elif _gm.progression_tracker.IsLevelCompleted(levelData.resource_path):
+				button.SetupButtonMode(LevelButton.LevelButtonMode.COMPLETE, levelIndex)
 			else:
-				if _gm.progression_tracker.IsLevelCompleted(levelData.levelName):
-					button.SetupButtonMode(LevelButton.LevelButtonMode.COMPLETE, levelIndex)
-				else:
-					button.SetupButtonMode(LevelButton.LevelButtonMode.INCOMPLETE, levelIndex)
+				button.SetupButtonMode(LevelButton.LevelButtonMode.INCOMPLETE, levelIndex)
 		else:
 			button.visible = false
 		levelIndex += 1


### PR DESCRIPTION
# Description

The skip button is currently unintuitive as in reality, it doesn't skip levels that someone hasn't beaten yet and just returns to level select. This small PR changes it and the skip button allows skipping levels to locked ones. It will unlock them but won't mark them as complete, the miniature will still feature blank level when it is implemented for all of them.

## Related issue(s)

https://github.com/Saplings-Projects/Birthday-2024/issues/83

## List of changes

A more detailed list of the changes.
- removed the path that leads to the level select screen when skipping to the locked level
- now skip button will lead to the next level unless it's the last one
- skip button will unlock levels but won;t mark them as complete
