### PR TITLE
Update base_piece.tscn

### DIFF
--- a/Birthday-2024-Project/ScenePrefabs/Pieces/base_piece.tscn
+++ b/Birthday-2024-Project/ScenePrefabs/Pieces/base_piece.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://cjih77cmvq7fm"]
+[gd_scene load_steps=9 format=3 uid="uid://ccdq0btysgv1m"]
 
 [ext_resource type="Script" path="res://Scripts/PieceLogic.gd" id="1_pb07g"]
 [ext_resource type="Resource" uid="uid://cmj62i48fgfhq" path="res://Resources/Audio/Samples/SfxRotateSamples.tres" id="2_jtldj"]


### PR DESCRIPTION
In Vorthein's PR, the uid of the base_piece prefab was changed. Other pieces refer to the old uid, so I am reverting it back to the previous uid.
The behavior of the inheriting pieces aren't affected even with the change, but I figured it would be better to revert it anyway