### PR TITLE
Fix for Credits text clipping

### DIFF
--- a/Birthday-2024-Project/ScenePrefabs/CreditsScreen.tscn
+++ b/Birthday-2024-Project/ScenePrefabs/CreditsScreen.tscn
@@ -110,6 +110,7 @@ offset_right = 550.0
 offset_bottom = 460.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_constants/separation = 10
 alignment = 1
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]

--- a/Birthday-2024-Project/ScenePrefabs/CreditsScreen.tscn
+++ b/Birthday-2024-Project/ScenePrefabs/CreditsScreen.tscn
@@ -110,7 +110,7 @@ offset_right = 550.0
 offset_bottom = 460.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_constants/separation = 10
+theme_override_constants/separation = 30
 alignment = 1
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
@@ -175,6 +175,7 @@ theme_override_constants/separation = 30
 alignment = 1
 
 [node name="Art" type="RichTextLabel" parent="VBoxContainer/HBoxContainer/CenterColumn"]
+clip_contents = false
 layout_mode = 2
 theme_override_font_sizes/normal_font_size = 30
 bbcode_enabled = true


### PR DESCRIPTION
# Description

When the credits window is resized or changes aspect ration (in settings), it clipped the bottom of the credits text. Just added a little padding

## Related issue(s)

https://github.com/Saplings-Projects/Birthday-2024/issues/99

## List of changes

- Added 10 padding to the Vbox between the credits text and copyright text