### PR TITLE
Editor Rotation Bug Fix

### DIFF
--- a/Birthday-2024-Project/Scripts/PieceLogic.gd
+++ b/Birthday-2024-Project/Scripts/PieceLogic.gd
@@ -185,7 +185,7 @@ func AssignMapGridCoordinates(assignedCoords : Vector2i):
 func RecordGridPosition(gridCoords : Vector2i):
 	_last_grid_position = gridCoords
 	_last_grid_rotation = current_rotation_state
-	_return_position = levelGridReference.GridCoordinateToPosition(gridCoords) - GetOriginCellOffset()
+	_return_position = levelGridReference.GridCoordinateToPosition(gridCoords) - GetOriginCellGoalOffset()
 	
 func return_piece(moveInstantly : bool = false):
 	current_placement_state = PlacementStates.UNPLACED


### PR DESCRIPTION
# Description

Fix to breaking the grid integrity by rapidly spinning pieces in editor mode

## Related issue(s)

https://github.com/Saplings-Projects/Birthday-2024/issues/41
https://github.com/Saplings-Projects/Birthday-2024/issues/53

## List of changes

- Returning pieces use goal rotation instead of current rotation
