### PR TITLE
Message Gallery duplicate message fix

### DIFF
--- a/Birthday-2024-Project/Scripts/UI/MessageGallery.gd
+++ b/Birthday-2024-Project/Scripts/UI/MessageGallery.gd
@@ -93,6 +93,21 @@ func LoadPage():
 				rightBigMsgBox.text = levelSetup.message
 				rightBigMsgBox.SwapTokens()
 				rightAuthorText.text = str(AUTHOR_PREFIX, levelSetup.author)
+	
+	#cleanup unused
+	if availableBoxes[0]:
+		(topLeftSmallMsgBox.get_parent() as Control).visible = false
+		(leftBigMsgBox.get_parent() as Control).visible = false
+	
+	if availableBoxes[1]:
+		(bottomLeftSmallMsgBox.get_parent() as Control).visible = false
+		
+	if availableBoxes[2]:
+		(topRightSmallMsgBox.get_parent() as Control).visible = false
+		(rightBigMsgBox.get_parent() as Control).visible = false
+		
+	if availableBoxes[3]:
+		(bottomRightSmallMsgBox.get_parent() as Control).visible = false
 
 func PrevPage():
 	if _currentPage == 0:


### PR DESCRIPTION
# Description

Message Gallery cleans up unused message boxes if a page doesn't use all 4 regions

## Related issue(s)

https://github.com/Saplings-Projects/Birthday-2024/issues/115

## List of changes

- Added a step after page load to check for unused regions and hide corresponding boxes
