### PR TITLE
Splash screen wait

### DIFF
--- a/Birthday-2024-Project/Scripts/ScreenManagement/SplashScreenController.gd
+++ b/Birthday-2024-Project/Scripts/ScreenManagement/SplashScreenController.gd
@@ -2,13 +2,16 @@ extends Node
 
 @export var myScreen : ScreenLogic
 @export var splashDuration : float = 2
+@export var entryWait : float = 0.5
 
+var _inputWaitTimer : float = 0
 var _timer : float = 0
 var _active : bool = false
 
 func ScreenEnter():
 	_active = true
 	_timer = splashDuration
+	_inputWaitTimer = entryWait
 	pass
 
 func GoToMainMenu():
@@ -18,8 +21,9 @@ func _process(delta):
 	if _active == false:
 		return
 	
+	_inputWaitTimer -= delta
 	_timer -= delta
-	if _timer < 0:
+	if _timer < 0 and _inputWaitTimer < 0:
 		GoToMainMenu()
 
 func _input(event):

--- a/Birthday-2024-Project/project.godot
+++ b/Birthday-2024-Project/project.godot
@@ -13,6 +13,7 @@ config_version=5
 config/name="Birthday-2024"
 run/main_scene="res://MainScenes/screen_mngr_init_scene.tscn"
 config/features=PackedStringArray("4.2", "GL Compatibility")
+boot_splash/bg_color=Color(0, 0, 0, 1)
 config/icon="res://icon.svg"
 
 [audio]
@@ -72,3 +73,4 @@ GrabPiece={
 textures/canvas_textures/default_texture_filter=2
 renderer/rendering_method="gl_compatibility"
 renderer/rendering_method.mobile="gl_compatibility"
+environment/defaults/default_clear_color=Color(0, 0, 0, 1)


### PR DESCRIPTION
# Description

Splash screen would transition early if the user clicked early enough before the splash screen appears.

When the resolution gets reseized, it flickers a screenless scene. Changing the screenless background color to black so it's not apparent. Also changed the Godot splash color to black to match the sapling splash

## List of changes

- Added minimum wait of 0.5 sec before splash screen registers click
- Changed screenless BG color to black
- Changed Godot splash screen color to black

## Additional notes

I hate that it changes the background color in editor too
