### PR TITLE
Stop pieces from being grabbed if mouse is hovering a button

### DIFF
--- a/Birthday-2024-Project/MainScenes/main_level.tscn
+++ b/Birthday-2024-Project/MainScenes/main_level.tscn
@@ -180,7 +180,7 @@ layer_0/tile_data = PackedInt32Array(-131075, 0, 0, -65539, 0, 0, -65538, 0, 0, 
 script = ExtResource("1_ywtrj")
 gameManager = NodePath("../../GameManager")
 
-[node name="GameManager" type="Node2D" parent="." node_paths=PackedStringArray("grid", "deletionZone", "myScreen", "levelNameText", "authorText", "empty_state", "play_state", "win_state", "edit_state")]
+[node name="GameManager" type="Node2D" parent="." node_paths=PackedStringArray("grid", "deletionZone", "myScreen", "levelNameText", "authorText", "puzzle_main_screen", "empty_state", "play_state", "win_state", "edit_state")]
 script = ExtResource("4_1cxrf")
 grid = NodePath("../GridCenter/GridMap")
 deletionZone = NodePath("../DeletionZone")
@@ -190,6 +190,7 @@ held_piece_distance_speed = 8.0
 place_piece_delay = 0.15
 levelNameText = NodePath("../Control/TextureRect/LevelName")
 authorText = NodePath("../Control/TextureRect2/Author")
+puzzle_main_screen = NodePath("../PuzzleUiManager/MainScreen/Panel")
 empty_state = NodePath("States/GameEmptyState")
 play_state = NodePath("States/GamePlayState")
 win_state = NodePath("States/GameWinState")

--- a/Birthday-2024-Project/Scripts/GameManager.gd
+++ b/Birthday-2024-Project/Scripts/GameManager.gd
@@ -44,7 +44,7 @@ func retrieve_mouse_position() -> Vector2:
 		return get_global_mouse_position()
 	return placing_locked_position
 	
-func is_mouse_in_button() -> bool:
+func is_mouse_over_button() -> bool:
 	return puzzle_main_screen.is_a_button_hovered()
 	
 func go_to_level_select():

--- a/Birthday-2024-Project/Scripts/GameManager.gd
+++ b/Birthday-2024-Project/Scripts/GameManager.gd
@@ -12,6 +12,8 @@ extends Node2D
 @export var levelNameText : Label
 @export var authorText : Label
 
+@export var puzzle_main_screen : PuzzleMainScreen
+
 @export_group("States")
 @export var empty_state: GameEmptyState
 @export var play_state: GamePlayState
@@ -41,7 +43,10 @@ func retrieve_mouse_position() -> Vector2:
 	if !placing_piece:
 		return get_global_mouse_position()
 	return placing_locked_position
-
+	
+func is_mouse_in_button() -> bool:
+	return puzzle_main_screen.is_a_button_hovered()
+	
 func go_to_level_select():
 	var thisLevelIndex : int = myScreen.transitionData[LevelsSelectMenu.PASS_LEVEL_INDEX_KEY]
 	var buttonsPerPage : int = myScreen.transitionData[LevelsSelectMenu.BUTTONS_PER_PAGE_KEY]

--- a/Birthday-2024-Project/Scripts/PieceLogic.gd
+++ b/Birthday-2024-Project/Scripts/PieceLogic.gd
@@ -289,7 +289,7 @@ func _input(event):
 			on_clicked(clicked_cell)
 
 func _check_shape_clicked() -> int:
-	if game_manager.is_mouse_in_button():
+	if game_manager.is_mouse_over_button():
 		return NO_CELL_CLICKED
 	
 	var relative_click_position : Vector2 = get_global_mouse_position() - GetOriginCellPosition()

--- a/Birthday-2024-Project/Scripts/PieceLogic.gd
+++ b/Birthday-2024-Project/Scripts/PieceLogic.gd
@@ -281,7 +281,7 @@ func _SetReturnPoint():
 	#print(global_position)
 
 func _input(event):
-	if event.is_action_pressed("GrabPiece"):
+	if event.is_action_pressed("GrabPiece") and totalCells > 0:
 		# Check if the user has clicked on the piece's exact shape
 		var clicked_cell : int = _check_shape_clicked()
 		if clicked_cell != NO_CELL_CLICKED:
@@ -289,6 +289,9 @@ func _input(event):
 			on_clicked(clicked_cell)
 
 func _check_shape_clicked() -> int:
+	if game_manager.is_mouse_in_button():
+		return NO_CELL_CLICKED
+	
 	var relative_click_position : Vector2 = get_global_mouse_position() - GetOriginCellPosition()
 	for i in range(_current_cells.size()):
 		var cell00 : Vector2 = Vector2((_current_cells[i].x - 0.5) * levelGridReference.tile_set.tile_size.x, (_current_cells[i].y - 0.5) * levelGridReference.tile_set.tile_size.y)

--- a/Birthday-2024-Project/Scripts/UI/Puzzle/PuzzleMainScreen.gd
+++ b/Birthday-2024-Project/Scripts/UI/Puzzle/PuzzleMainScreen.gd
@@ -21,3 +21,22 @@ func show_hide_win_text(is_showing: bool):
 	else:
 		win_text.hide()
 
+func is_a_button_hovered() -> bool:
+	var buttons = [
+		exit_button, 
+		reset_button, 
+		back_button, 
+		skip_button, 
+		settings_button, 
+		edit_button, 
+		library_button, 
+		import_button, 
+		export_button]
+	
+	var hitboxes = []
+	
+	for b : Button in buttons:
+		if b.visible and b.is_hovered():
+			return true
+	
+	return false


### PR DESCRIPTION
# Description

If the mouse is hovering a button in the play level, pieces will not be grabbed when clicking even if one or more are behind it.

## Related issue(s)

#116 

## List of changes

- Added a function to PuzzleMainScreen that checks if any of its visible buttons are being hovered by the mouse
- Added a reference to PuzzleMainScreen in GameManager and a function that calls the previous function
- Added logic to PieceLogic that checks if the mouse is over a button and decides it is not clicked


