### PR TITLE
Removing the ? at the end of Quit and Restart

### DIFF
--- a/Birthday-2024-Project/Scripts/Game/States/GameEditState.gd
+++ b/Birthday-2024-Project/Scripts/Game/States/GameEditState.gd
@@ -3,7 +3,7 @@ extends GameState
 
 func reset_puzzle():
 	manager.myScreen.ScreenEnter.connect(ResetConfirmation)
-	manager.myScreen.ShowConfirmationPopup("Restart?", "Are you sure you want clear all pieces?", "Yes", "No")
+	manager.myScreen.ShowConfirmationPopup("Restart", "Are you sure you want clear all pieces?", "Yes", "No")
 
 func _reset_puzzle():
 	manager.grid.ClearLevel()

--- a/Birthday-2024-Project/Scripts/ScreenManagement/ScreenLogic.gd
+++ b/Birthday-2024-Project/Scripts/ScreenManagement/ScreenLogic.gd
@@ -29,7 +29,7 @@ func ShowDisplayPopup(title : String, body : String, displayPieces : Array[Packe
 
 func ExitApplication():
 	ScreenEnter.connect(ExitConfirmation)
-	ShowConfirmationPopup("Quit?", "Are you sure you want to quit?", "Yes", "No")
+	ShowConfirmationPopup("Quit", "Are you sure you want to quit?", "Yes", "No")
 	
 func ExitConfirmation():
 	#if yes


### PR DESCRIPTION
# Description

Removing the ? at the end of Quit and Restart titles to match other popups

## List of changes

- Removed ? at the end of Quit confirmation popup
- Removed ? at the end of Restart confirmation popup in Editor