### PR TITLE
Introduced small delay before animation start playing

### DIFF
--- a/Birthday-2024-Project/Scripts/UI/Puzzle/PuzzleMainScreen.gd
+++ b/Birthday-2024-Project/Scripts/UI/Puzzle/PuzzleMainScreen.gd
@@ -23,6 +23,7 @@ extends Control
 @export var shutterAnimation : AnimationPlayer
 
 func play_win_animation():
+	await get_tree().create_timer(0.05).timeout
 	var screenCapture = gridViewport.get_texture().get_image()
 	var tex = ImageTexture.create_from_image(screenCapture)
 	photoTexture.texture = tex


### PR DESCRIPTION
# Description

I've noticed that the snapshot for completion photo takes place immediately after the final piece is in place. This causes the grid to still be gray for this piece. Small delay fixes it.
Without delay:
![image](https://github.com/Saplings-Projects/Birthday-2024/assets/150629422/c5a5606f-f125-4e4c-b7ef-a60b60638c03)
With delay:
![image](https://github.com/Saplings-Projects/Birthday-2024/assets/150629422/23818f9a-ace7-4104-9674-7ebfebda1a6d)

# Related issues
https://github.com/Saplings-Projects/Birthday-2024/issues/141

