### PR TITLE
Changed "New Faunas" to "New pieces" where blockers were introduced alongside Fauna pieces

### DIFF
--- a/Birthday-2024-Project/Resources/TutorialData/TutorialLevel10.tres
+++ b/Birthday-2024-Project/Resources/TutorialData/TutorialLevel10.tres
@@ -7,6 +7,6 @@
 
 [resource]
 script = ExtResource("1_5pg0n")
-title = "New Faunas"
+title = "New pieces"
 body = "Man, smol Faunas' cuteness is beyond Saplings' comprehension. Whether it's the first iteration or the Halloween edition, you just can't get enough of Fauna. But be careful with this matcha set!"
 displayPieces = Array[PackedScene]([ExtResource("1_16p12"), ExtResource("2_a7a6t"), ExtResource("3_c4r0o")])

--- a/Birthday-2024-Project/Resources/TutorialData/TutorialLevel3.tres
+++ b/Birthday-2024-Project/Resources/TutorialData/TutorialLevel3.tres
@@ -7,6 +7,6 @@
 
 [resource]
 script = ExtResource("1_gw210")
-title = "New Faunas"
+title = "New pieces"
 body = "Nice! Now in addition to new Faunas, you might also see decorations. These pieces can't be moved but you can enjoy looking at them. Here's the fabled golden apple accompanied by Hungry Faunya and Happy Fauna."
 displayPieces = Array[PackedScene]([ExtResource("1_viddd"), ExtResource("2_0v142"), ExtResource("3_qgr4u")])

--- a/Birthday-2024-Project/Resources/TutorialData/TutorialLevel7.tres
+++ b/Birthday-2024-Project/Resources/TutorialData/TutorialLevel7.tres
@@ -7,6 +7,6 @@
 
 [resource]
 script = ExtResource("1_g7nnu")
-title = "New Faunas"
+title = "New pieces"
 body = "There's a lot more to see. Here we have Fauna in her casual outfit and Fauna in her less casual outfit. One is ready to stream, and the other is ready to teach the Promise girls the art of speedrunning. Enormous matcha is here in case of caffeine withdrawal."
 displayPieces = Array[PackedScene]([ExtResource("1_7cmpt"), ExtResource("2_4nmub"), ExtResource("3_slew5")])

--- a/Birthday-2024-Project/Resources/TutorialData/TutorialLevel8.tres
+++ b/Birthday-2024-Project/Resources/TutorialData/TutorialLevel8.tres
@@ -7,6 +7,6 @@
 
 [resource]
 script = ExtResource("1_ogd1l")
-title = "New Faunas"
+title = "New pieces"
 body = "Agent Fauna7 and her trusty wrench have arrived just in time to see Idol Fauna's performance. Wait, what do you mean 5th fes is already over?!"
 displayPieces = Array[PackedScene]([ExtResource("1_x5uhy"), ExtResource("2_3qquh"), ExtResource("3_wxxfb")])

--- a/Birthday-2024-Project/Resources/TutorialData/TutorialLevel9.tres
+++ b/Birthday-2024-Project/Resources/TutorialData/TutorialLevel9.tres
@@ -7,6 +7,6 @@
 
 [resource]
 script = ExtResource("1_8vhnj")
-title = "New Faunas"
+title = "New pieces"
 body = "What is wider? Wide Fauna's head or Cape Fauna's horn warmers? Well, it's not important now. This fine cat gentleman is waiting for your attention."
 displayPieces = Array[PackedScene]([ExtResource("1_7pd24"), ExtResource("2_jnedm"), ExtResource("3_hibpk")])


### PR DESCRIPTION
# Description

Having new Faunas text where not only Faunas were introduced seemed a bit weird

## List of changes

A more detailed list of the changes.
- Changed "New Faunas" to "New pieces" in tutorial prompts with new blockers
