### PR TITLE
Adjusting Safe Zone

### DIFF
--- a/Birthday-2024-Project/Scripts/GridLogic.gd
+++ b/Birthday-2024-Project/Scripts/GridLogic.gd
@@ -295,6 +295,13 @@ func CheckIfOutsideSafeZone(piece : PieceLogic) -> bool:
 	var cellOffsetsArray : Array[Vector2i] = piece.GetPieceShapeOffsetArray()
 	for shapeCell in cellOffsetsArray:
 		var spaceCoord : Vector2i = pieceCoords + shapeCell
+		
+		#Correcting for 0 order with negatives
+		if spaceCoord.x < 0:
+			spaceCoord.x += 1
+		if spaceCoord.y < 0:
+			spaceCoord.y += 1
+		
 		# if at least 1 square is in view
 		if abs(spaceCoord.x) < SAFE_WIDTH and abs(spaceCoord.y) < SAFE_HEIGHT:
 			return false


### PR DESCRIPTION
# Description

Instead of widening the area, I fixed the imbalance between positive and negative numbers.
Now left is no longer cut short

## Related issue(s)

https://github.com/Saplings-Projects/Birthday-2024/issues/142

## List of changes

- When calculating safe position, if negative, add one

## Additional notes

It's still somewhat conservative because rotating Cape Fauna can lead to some bad situations otherwise
