### PR TITLE
Default as Windowed

### DIFF
--- a/Birthday-2024-Project/Scripts/Model/Prefs/VideoPreferences.gd
+++ b/Birthday-2024-Project/Scripts/Model/Prefs/VideoPreferences.gd
@@ -6,9 +6,9 @@ var height: int
 var width: int
 var window: WindowType
 
-const _DEFAULT_HEIGHT: int = 1080
-const _DEFAULT_WIDTH: int = 1920
-const _DEFAULT_WINDOW: WindowType = WindowType.FULLSCREEN
+const _DEFAULT_HEIGHT: int = 900
+const _DEFAULT_WIDTH: int = 1600
+const _DEFAULT_WINDOW: WindowType = WindowType.WINDOWED
 const _SECTION_NAME: String = "video"
 
 


### PR DESCRIPTION
# Description

Users are reporting initializing in fullscreen but it's off-screen so they have no window bar to grab or access to the options button.

Setting default preference to windowed.
Setting default size preference to smaller than 1080 so it's not off the screen