### PR TITLE
Flicker Bug Fix

### DIFF
--- a/Birthday-2024-Project/Scripts/ScreenManagement/ScreenManager.gd
+++ b/Birthday-2024-Project/Scripts/ScreenManagement/ScreenManager.gd
@@ -26,6 +26,7 @@ func GoToScreen(screen : PackedScene, data : Dictionary, transitionStyle: Transi
 
 	if transitionStyle != TransitionStyle.NONE:
 		_animationActive = true
+		await get_tree().create_timer(0.05).timeout
 		var screenCapture = get_viewport().get_texture().get_image()
 		var tex = ImageTexture.create_from_image(screenCapture)
 		screenTexture.texture = tex


### PR DESCRIPTION
# Description

Tiny wait before taking screen capture when transitioning scenes, so it doesn't capture the darkened screen

## Related issue(s)

https://github.com/Saplings-Projects/Birthday-2024/issues/153