### PR TITLE
Default Fauna sound frequency set to 50%

### DIFF
--- a/Birthday-2024-Project/Scripts/Model/Prefs/AudioPreferences.gd
+++ b/Birthday-2024-Project/Scripts/Model/Prefs/AudioPreferences.gd
@@ -12,7 +12,7 @@ const _DEFAULT_MASTER: float = 1.0
 const _DEFAULT_MUSIC: float = 0.25
 const _DEFAULT_SFX: float = 0.35
 const _DEFAULT_FAUNA: float = 0.5
-const _DEFAULT_FREQ: float = 100
+const _DEFAULT_FREQ: float = 50
 const _SECTION_NAME: String = "audio"
 
 


### PR DESCRIPTION
# Description

Audio preferences will have 50% as the starting Fauna noise frequency at first launch

## Related issue(s)

https://github.com/Saplings-Projects/Birthday-2024/issues/155
