### PR TITLE
Placement and size change of server mention

### DIFF
--- a/Birthday-2024-Project/ScenePrefabs/CreditsScreen.tscn
+++ b/Birthday-2024-Project/ScenePrefabs/CreditsScreen.tscn
@@ -344,24 +344,24 @@ RaddLad
 fit_content = true
 scroll_active = false
 
-[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer"]
+[node name="Server Container" type="VBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
 
-[node name="Cover Credits" type="RichTextLabel" parent="VBoxContainer/VBoxContainer"]
+[node name="Server Text" type="RichTextLabel" parent="VBoxContainer/Server Container"]
+layout_mode = 2
+bbcode_enabled = true
+text = "[center][font_size=25]Made possible thanks to the community of Fauna's Forest Server[/font_size][/center]"
+fit_content = true
+scroll_active = false
+
+[node name="Copyright Container" type="VBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="Cover Credits" type="RichTextLabel" parent="VBoxContainer/Copyright Container"]
 layout_mode = 2
 bbcode_enabled = true
 text = "[center][font_size=25]Hololive and its Talents are copyrights of COVER Corp. © 2016. All rights reserved.[/font_size]
 [/center]"
-fit_content = true
-scroll_active = false
-
-[node name="VBoxContainer2" type="VBoxContainer" parent="VBoxContainer"]
-layout_mode = 2
-
-[node name="RichTextLabel" type="RichTextLabel" parent="VBoxContainer/VBoxContainer2"]
-layout_mode = 2
-bbcode_enabled = true
-text = "[center][font_size=20]Made possible thanks to the community of Fauna's Forest Server[/font_size][/center]"
 fit_content = true
 scroll_active = false
 


### PR DESCRIPTION
# Description

Following feedback from https://github.com/Saplings-Projects/Birthday-2024/issues/154

## Related issue(s)

https://github.com/Saplings-Projects/Birthday-2024/issues/154

## List of changes

A more detailed list of the changes.
- increased size of server mention to 25
- moved it over the COVER text
- renamed nodes to meaningful names
