### PR TITLE
Adjust time between particles

### DIFF
--- a/Birthday-2024-Project/ScenePrefabs/PuzzleUiManager.tscn
+++ b/Birthday-2024-Project/ScenePrefabs/PuzzleUiManager.tscn
@@ -139,7 +139,7 @@ _data = {
 }
 
 [sub_resource type="Curve" id="Curve_sv41s"]
-_data = [Vector2(0, 1), 0.0, 0.0, 0, 0, Vector2(1, 0), -2.69024, 0.0, 0, 0]
+_data = [Vector2(0, 1), 0.0, 0.0, 0, 0, Vector2(0.5, 0), -2.69024, 0.0, 0, 0]
 point_count = 2
 
 [sub_resource type="CurveTexture" id="CurveTexture_mwpqh"]
@@ -1398,8 +1398,7 @@ emitting = false
 amount = 10
 process_material = SubResource("ParticleProcessMaterial_ueaj4")
 texture = ExtResource("11_rkgxl")
-lifetime = 1.2
-one_shot = true
+lifetime = 3.0
 explosiveness = 1.0
 fixed_fps = 60
 
@@ -2001,7 +2000,7 @@ anchor_bottom = 1.0
 offset_left = -100.0
 offset_top = -101.0
 offset_right = 100.0
-offset_bottom = -0.00209045
+offset_bottom = -0.00218201
 grow_horizontal = 2
 grow_vertical = 0
 text = "OK"


### PR DESCRIPTION
# Description

Increasing the lifetime particle emission cycles, so there is more time between each burst

## List of changes

- Increasing lifetime of particle emission cycles
- Visibility fades out sooner to keep the visuals around the same as before

## Additional notes

This is more a preference change to make the particles less obnoxious. Not that they were that bad