### PR TITLE
Button flicker fix

### DIFF
--- a/Birthday-2024-Project/Scripts/ScreenManagement/ScreenManager.gd
+++ b/Birthday-2024-Project/Scripts/ScreenManagement/ScreenManager.gd
@@ -26,7 +26,6 @@ func GoToScreen(screen : PackedScene, data : Dictionary, transitionStyle: Transi
 
 	if transitionStyle != TransitionStyle.NONE:
 		_animationActive = true
-		await get_tree().create_timer(0.1).timeout
 		var screenCapture = get_viewport().get_texture().get_image()
 		var tex = ImageTexture.create_from_image(screenCapture)
 		screenTexture.texture = tex

--- a/Birthday-2024-Project/Scripts/ScreenManagement/ScreenManager.gd
+++ b/Birthday-2024-Project/Scripts/ScreenManagement/ScreenManager.gd
@@ -26,7 +26,7 @@ func GoToScreen(screen : PackedScene, data : Dictionary, transitionStyle: Transi
 
 	if transitionStyle != TransitionStyle.NONE:
 		_animationActive = true
-		await get_tree().create_timer(0.05).timeout
+		await get_tree().create_timer(0.1).timeout
 		var screenCapture = get_viewport().get_texture().get_image()
 		var tex = ImageTexture.create_from_image(screenCapture)
 		screenTexture.texture = tex

--- a/Birthday-2024-Project/Scripts/ScreenManagement/TextPopupController.gd
+++ b/Birthday-2024-Project/Scripts/ScreenManagement/TextPopupController.gd
@@ -20,4 +20,6 @@ func onScreenEnter():
 func onClose():
 	animator.play("PopupAnimations/Exit")
 	await animator.animation_finished
+	#extra wait so shadow is gone
+	await get_tree().create_timer(0.05).timeout
 	myScreen.ClosePopup()

--- a/Birthday-2024-Project/Scripts/ScreenManagement/TextPopupController.gd
+++ b/Birthday-2024-Project/Scripts/ScreenManagement/TextPopupController.gd
@@ -20,6 +20,5 @@ func onScreenEnter():
 func onClose():
 	animator.play("PopupAnimations/Exit")
 	await animator.animation_finished
-	#extra wait so shadow is gone
 	await get_tree().create_timer(0.05).timeout
 	myScreen.ClosePopup()


### PR DESCRIPTION
# Description

Buttons would sometime flicker between pressed and hovered state depending on how fast you clicked and when the screen gets captured. Most noticeable on the Campaign Select screen.
Additionally, the wait made it so you can still give inputs in that 0.05 seconds time before the animation puts up a blocker.

Moved the wait to the popup close functionality. Now the transition has instant response again.

## Related issue(s)

https://github.com/Saplings-Projects/Birthday-2024/issues/169

## List of changes

- Removed tiny pre-wait for scene transition animation
- Added tiny wait after the popup animation finishes before it closes
- 
## Additional notes

The darken on popups remains when transitioning, but it's not that bad. At least, it didn't seem to flicker
