### PR TITLE
Regular Fullscreen instead of Exclusive Fullscreen

### DIFF
--- a/Birthday-2024-Project/ScenePrefabs/SettingsWindow.tscn
+++ b/Birthday-2024-Project/ScenePrefabs/SettingsWindow.tscn
@@ -121,14 +121,12 @@ text = "Window Mode"
 
 [node name="WindowOptions" type="OptionButton" parent="Panel/ThemeHolder/TabContainer/Video/MarginContainer/Settings Container/WindowContainer"]
 layout_mode = 2
-item_count = 3
+item_count = 2
 selected = 0
 popup/item_0/text = "Fullscreen"
 popup/item_0/id = 0
 popup/item_1/text = "Windowed"
 popup/item_1/id = 1
-popup/item_2/text = "Windowed Borderless"
-popup/item_2/id = 2
 
 [node name="ResolutionContainer" type="VBoxContainer" parent="Panel/ThemeHolder/TabContainer/Video/MarginContainer/Settings Container"]
 layout_mode = 2

--- a/Birthday-2024-Project/Scripts/Game/VideoController.gd
+++ b/Birthday-2024-Project/Scripts/Game/VideoController.gd
@@ -10,15 +10,15 @@ var _prefs: VideoPreferences
 func enable_fullscreen():
 	_prefs.window = VideoPreferences.WindowType.FULLSCREEN
 	
-	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN)
 	DisplayServer.window_set_flag(DisplayServer.WINDOW_FLAG_BORDERLESS, false)
+	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_FULLSCREEN)
 
 
 func enable_windowed():
 	_prefs.window = VideoPreferences.WindowType.WINDOWED
 	
-	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
 	DisplayServer.window_set_flag(DisplayServer.WINDOW_FLAG_BORDERLESS, false)
+	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
 	
 	_resize_window()
 
@@ -26,8 +26,8 @@ func enable_windowed():
 func enable_windowed_borderless():
 	_prefs.window = VideoPreferences.WindowType.WINDOWED_BORDERLESS
 	
-	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_MAXIMIZED)
 	DisplayServer.window_set_flag(DisplayServer.WINDOW_FLAG_BORDERLESS, true)
+	DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_MAXIMIZED)
 
 
 func set_resolution(res_idx: int):

--- a/Birthday-2024-Project/Scripts/Game/VideoController.gd
+++ b/Birthday-2024-Project/Scripts/Game/VideoController.gd
@@ -55,7 +55,8 @@ func _apply_prefs():
 		VideoPreferences.WindowType.WINDOWED:
 			enable_windowed()
 		VideoPreferences.WindowType.WINDOWED_BORDERLESS:
-			enable_windowed_borderless()
+			#enable_windowed_borderless()
+			enable_fullscreen()
 		_:
 			printerr("Unknown window type for video preference: ", _prefs.window)
 

--- a/Birthday-2024-Project/Scripts/UI/Settings/VideoSettingsControl.gd
+++ b/Birthday-2024-Project/Scripts/UI/Settings/VideoSettingsControl.gd
@@ -64,7 +64,8 @@ func _on_window_selected(index: int):
 			_gm.video_controller.enable_windowed()
 		VideoPreferences.WindowType.WINDOWED_BORDERLESS:
 			resolution_options.disabled = true
-			_gm.video_controller.enable_windowed_borderless()
+			#_gm.video_controller.enable_windowed_borderless()
+			_gm.video_controller.enable_fullscreen()
 		_:
 			printerr("Unhandled screen type selected")
 	


### PR DESCRIPTION
# Description

I have a suspicion that some of the weirdness when first launching the game is due to Exclusive Fullscreen.
Since it takes control of the screen and interacts with the gpu.
This changes the fullscreen option to Godot's regular fullscreen mode.

Additionally, fullscreen mode and borderless windowed are effectively the same as far as Godot is concerned, so I removed borderless windowed as an option.

## List of changes

- Removed Borderless Window option from settings popup
- Switched Exclusive Fullscreen mode to regular Fullscreen mode
- Swapped border flags to before (though, I doubt it matters)
- Replaced Borderless Window cases with Fullscreen in case players still have the Borderless Window preference in their save

## Additional notes

As far as I can tell, Exclusive Fullscreen is not commonly used anymore. People seem to encounter more issues when using Exclusive Fullscreen in general (in all forms of game development). Nothing seems definitive, but I figure we can apply this change and see if the problems still occur after more playtesting
